### PR TITLE
fix(TRV13/2.0.0): make REQUIRED_ITEM_ADDON_ID conditional on add_ons presence

### DIFF
--- a/src/config/build.yaml
+++ b/src/config/build.yaml
@@ -1,0 +1,9449 @@
+openapi: 3.0.0
+info:
+  title: ONDC Specification
+  description: ONDC Specification
+  version: 2.0.0
+security:
+  - SubscriberAuth: []
+paths:
+  /search:
+    post:
+      tags:
+        - Provider Platform
+        - Gateway
+      description: >-
+        Consumer Platform declares the customer's intent to buy/avail products
+        or services
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - properties:
+                        action:
+                          enum:
+                            - search
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    intent:
+                      $ref: "#/components/schemas/Intent"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /select:
+    post:
+      tags:
+        - Provider Platform
+      description: >-
+        Consumer Platform declares the customer's cart (or equivalent) created
+        by selecting objects from the catalog
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - select
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    order:
+                      $ref: "#/components/schemas/Order"
+                  required:
+                    - order
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /init:
+    post:
+      tags:
+        - Provider Platform
+      description: Initialize an order by providing billing and/or shipping details
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - init
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    order:
+                      $ref: "#/components/schemas/Order"
+                  required:
+                    - order
+              required:
+                - context
+                - message
+      responses:
+        default:
+          description: >-
+            Acknowledgement of message received after successful validation of
+            schema and signature
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: object
+                    properties:
+                      ack:
+                        allOf:
+                          - $ref: "#/components/schemas/Ack"
+                          - type: object
+                          - properties:
+                              status:
+                                enum:
+                                  - ACK
+                                  - NACK
+                    required:
+                      - ack
+                  error:
+                    $ref: "#/components/schemas/Error"
+                required:
+                  - message
+  /confirm:
+    post:
+      tags:
+        - Provider Platform
+      description: Initialize an order by providing billing and/or shipping details
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - confirm
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    order:
+                      $ref: "#/components/schemas/Order"
+                  required:
+                    - order
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /status:
+    post:
+      tags:
+        - Provider Platform
+      description: Fetch the latest order object
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - status
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    ref_id:
+                      $ref: "#/components/schemas/Order/properties/id"
+                    order_id:
+                      $ref: "#/components/schemas/Order/properties/id"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /track:
+    post:
+      tags:
+        - Provider Platform
+      description: Track an active order
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - track
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    order_id:
+                      $ref: "#/components/schemas/Order/properties/id"
+                    callback_url:
+                      type: string
+                      format: uri
+                  required:
+                    - order_id
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /cancel:
+    post:
+      tags:
+        - Provider Platform
+      description: Cancel an order
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - cancel
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    order_id:
+                      $ref: "#/components/schemas/Order/properties/id"
+                    cancellation_reason_id:
+                      $ref: "#/components/schemas/Option/properties/id"
+                    descriptor:
+                      $ref: "#/components/schemas/Descriptor"
+                  required:
+                    - order_id
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /update:
+    post:
+      tags:
+        - Provider Platform
+      description: Remove object
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - update
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    update_target:
+                      description: >-
+                        Comma separated values of order objects being updated.
+                        For example:
+                        ```"update_target":"item,billing,fulfillment"```
+                      type: string
+                    order:
+                      description: Updated order object
+                      allOf:
+                        - $ref: "#/components/schemas/Order"
+                  required:
+                    - update_target
+                    - order
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /rating:
+    post:
+      tags:
+        - Provider Platform
+      description: Provide feedback on a service
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - rating
+                      required:
+                        - action
+                message:
+                  type: object
+                  properties:
+                    ratings:
+                      type: array
+                      items:
+                        $ref: "#/components/schemas/Rating"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /support:
+    post:
+      tags:
+        - Provider Platform
+      description: Contact support
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - support
+                      required:
+                        - action
+                message:
+                  type: object
+                  properties:
+                    support:
+                      $ref: "#/components/schemas/Support"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /on_search:
+    post:
+      tags:
+        - Consumer Platform
+      description: Provider Platform sends its catalog in response to a search request.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - on_search
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    catalog:
+                      $ref: "#/components/schemas/Catalog"
+                  required:
+                    - catalog
+                error:
+                  $ref: "#/components/schemas/Error"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /on_select:
+    post:
+      tags:
+        - Consumer Platform
+      description: Send draft order object with quoted price for selected items
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - on_select
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    order:
+                      $ref: "#/components/schemas/Order"
+                error:
+                  $ref: "#/components/schemas/Error"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /on_init:
+    post:
+      tags:
+        - Consumer Platform
+      description: Send order object with payment details updated
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - on_init
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    order:
+                      $ref: "#/components/schemas/Order"
+                  required:
+                    - order
+                error:
+                  $ref: "#/components/schemas/Error"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /on_confirm:
+    post:
+      tags:
+        - Consumer Platform
+      description: Send active order object
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - on_confirm
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    order:
+                      $ref: "#/components/schemas/Order"
+                  required:
+                    - order
+                error:
+                  $ref: "#/components/schemas/Error"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /on_track:
+    post:
+      tags:
+        - Consumer Platform
+      description: Send tracking details of an active order
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - on_track
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    tracking:
+                      $ref: "#/components/schemas/Tracking"
+                  required:
+                    - tracking
+                error:
+                  $ref: "#/components/schemas/Error"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /on_cancel:
+    post:
+      tags:
+        - Consumer Platform
+      description: >-
+        Send cancellation request_id with reasons list in case of cancellation
+        request. Else send cancelled order object
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - on_cancel
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    order:
+                      $ref: "#/components/schemas/Order"
+                  required:
+                    - order
+                error:
+                  $ref: "#/components/schemas/Error"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /on_update:
+    post:
+      tags:
+        - Consumer Platform
+      description: Returns updated service with updated runtime object
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - on_update
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    order:
+                      $ref: "#/components/schemas/Order"
+                  required:
+                    - order
+                error:
+                  $ref: "#/components/schemas/Error"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /on_status:
+    post:
+      tags:
+        - Consumer Platform
+      description: Fetch the status of a Service
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - on_status
+                      required:
+                        - action
+                message:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    order:
+                      $ref: "#/components/schemas/Order"
+                  required:
+                    - order
+                error:
+                  $ref: "#/components/schemas/Error"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /on_rating:
+    post:
+      tags:
+        - Consumer Platform
+      description: Provide feedback on a service
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - on_rating
+                      required:
+                        - action
+                message:
+                  type: object
+                  properties:
+                    feedback_form:
+                      description: >-
+                        A feedback form to allow the user to provide additional
+                        information on the rating provided
+                      allOf:
+                        - $ref: "#/components/schemas/XInput"
+                error:
+                  $ref: "#/components/schemas/Error"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+  /on_support:
+    post:
+      tags:
+        - Consumer Platform
+      description: Contact Support
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                context:
+                  allOf:
+                    - $ref: "#/components/schemas/Context"
+                    - type: object
+                      properties:
+                        action:
+                          enum:
+                            - on_support
+                      required:
+                        - action
+                message:
+                  type: object
+                  properties:
+                    support:
+                      $ref: "#/components/schemas/Support"
+                error:
+                  $ref: "#/components/schemas/Error"
+              required:
+                - context
+                - message
+      responses:
+        default:
+          $ref: "#/paths/~1init/post/responses/default"
+components:
+  securitySchemes:
+    SubscriberAuth:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: >-
+        Signature of message body using Consumer Platform or Provider Platform
+        subscriber's signing public key.
+        <br/><br/>Format:<br/><br/><code>Authorization : Signature
+        keyId="{subscriber_id}|{unique_key_id}|{algorithm}",algorithm="ed25519",created="1606970629",expires="1607030629",headers="(created)
+        (expires) digest",signature="Base64(signing string)"</code>
+  schemas:
+    Ack:
+      description: >-
+        Describes the acknowledgement sent in response to an API call. If the
+        implementation uses HTTP/S, then Ack must be returned in the same
+        session. Every API call to a BPP must be responded to with an Ack
+        whether the BPP intends to respond with a callback or not. This has one
+        property called `status` that indicates the status of the
+        Acknowledgement.
+      type: object
+      additionalProperties: false
+      properties:
+        status:
+          type: string
+          description: >-
+            The status of the acknowledgement. If the request passes the
+            validation criteria of the BPP, then this is set to ACK. If a BPP
+            responds with status = `ACK` to a request, it is required to respond
+            with a callback. If the request fails the validation criteria, then
+            this is set to NACK. Additionally, if a BPP does not intend to
+            respond with a callback even after the request meets the validation
+            criteria, it should set this value to `NACK`.
+          enum:
+            - ACK
+            - NACK
+        tags:
+          description: >-
+            A list of tags containing any additional information sent along with
+            the Acknowledgement.
+          type: array
+          items:
+            $ref: "#/components/schemas/TagGroup"
+    AddOn:
+      description: >-
+        Describes an additional item offered as a value-addition to a product or
+        service. This does not exist independently in a catalog and is always
+        associated with an item.
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          description: Provider-defined ID of the add-on
+          type: string
+        descriptor:
+          $ref: "#/components/schemas/Descriptor"
+        price:
+          $ref: "#/components/schemas/Price"
+        quantity:
+          $ref: "#/components/schemas/ItemQuantity"
+    Address:
+      description: Describes a postal address.
+      type: string
+    Agent:
+      description: >-
+        Describes the direct performer, driver or executor that fulfills an
+        order. It is usually a person. But in some rare cases, it could be a
+        non-living entity like a drone, or a bot. Some examples of agents are
+        Doctor in the healthcare sector, a driver in the mobility sector, or a
+        delivery person in the logistics sector. This object can be set at any
+        stage of the order lifecycle. This can be set at the discovery stage
+        when the BPP wants to provide details on the agent fulfilling the order,
+        like in healthcare, where the doctor's name appears during search. This
+        object can also used to search for a particular person that the customer
+        wants fulfilling an order. Sometimes, this object gets instantiated
+        after the order is confirmed, like in the case of on-demand taxis, where
+        the driver is assigned after the user confirms the ride.
+      type: object
+      additionalProperties: false
+      properties:
+        person:
+          $ref: "#/components/schemas/Person"
+        contact:
+          $ref: "#/components/schemas/Contact"
+        organization:
+          $ref: "#/components/schemas/Organization"
+        rating:
+          $ref: "#/components/schemas/Rating/properties/value"
+    Authorization:
+      description: >-
+        Describes an authorization mechanism used to start or end the
+        fulfillment of an order. For example, in the mobility sector, the driver
+        may require a one-time password to initiate the ride. In the healthcare
+        sector, a patient may need to provide a password to open a video
+        conference link during a teleconsultation.
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          description: >-
+            Type of authorization mechanism used. The allowed values for this
+            field can be published as part of the network policy.
+          type: string
+        token:
+          description: >-
+            Token used for authorization. This is typically generated at the
+            BPP. The BAP can send this value to the user via any channel that it
+            uses to authenticate the user like SMS, Email, Push notification, or
+            in-app rendering.
+          type: string
+        valid_from:
+          description: Timestamp in RFC3339 format from which token is valid
+          type: string
+          format: date-time
+        valid_to:
+          description: Timestamp in RFC3339 format until which token is valid
+          type: string
+          format: date-time
+        status:
+          description: Status of the token
+          type: string
+    Billing:
+      description: >-
+        Describes the billing details of an entity.<br>This has properties like
+        name,organization,address,email,phone,time,tax_number,
+        created_at,updated_at
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          description: Name of the billable entity
+          type: string
+        organization:
+          description: Details of the organization being billed.
+          allOf:
+            - $ref: "#/components/schemas/Organization"
+        address:
+          description: The address of the billable entity
+          allOf:
+            - $ref: "#/components/schemas/Address"
+        state:
+          description: >-
+            The state where the billable entity resides. This is important for
+            state-level tax calculation
+          allOf:
+            - $ref: "#/components/schemas/State"
+        city:
+          description: The city where the billable entity resides.
+          allOf:
+            - $ref: "#/components/schemas/City"
+        email:
+          description: Email address where the bill is sent to
+          type: string
+          format: email
+        phone:
+          description: Phone number of the billable entity
+          type: string
+        time:
+          description: Details regarding the billing period
+          allOf:
+            - $ref: "#/components/schemas/Time"
+        tax_id:
+          description: ID of the billable entity as recognized by the taxation authority
+          type: string
+    Cancellation:
+      description: Describes a cancellation event
+      type: object
+      additionalProperties: false
+      properties:
+        time:
+          description: Date-time when the order was cancelled by the buyer
+          type: string
+          format: date-time
+        cancelled_by:
+          type: string
+          enum:
+            - CONSUMER
+            - PROVIDER
+        reason:
+          description: The reason for cancellation
+          allOf:
+            - $ref: "#/components/schemas/Option"
+        additional_description:
+          description: Any additional information regarding the nature of cancellation
+          allOf:
+            - $ref: "#/components/schemas/Descriptor"
+    CancellationTerm:
+      description: >-
+        Describes the cancellation terms of an item or an order. This can be
+        referenced at an item or order level. Item-level cancellation terms can
+        override the terms at the order level.
+      type: object
+      additionalProperties: false
+      properties:
+        fulfillment_state:
+          description: The state of fulfillment during which this term is applicable.
+          allOf:
+            - $ref: "#/components/schemas/FulfillmentState"
+        reason_required:
+          description: Indicates whether a reason is required to cancel the order
+          type: boolean
+        cancel_by:
+          description: Information related to the time of cancellation.
+          allOf:
+            - $ref: "#/components/schemas/Time"
+        cancellation_fee:
+          $ref: "#/components/schemas/Fee"
+        xinput:
+          $ref: "#/components/schemas/XInput"
+        external_ref:
+          $ref: "#/components/schemas/MediaFile"
+    Catalog:
+      description: >-
+        Describes the products or services offered by a BPP. This is typically
+        sent as the response to a search intent from a BAP. The payment terms,
+        offers and terms of fulfillment supported by the BPP can also be
+        included here. The BPP can show hierarchical nature of products/services
+        in its catalog using the parent_category_id in categories. The BPP can
+        also send a ttl (time to live) in the context which is the duration for
+        which a BAP can cache the catalog and use the cached catalog.  <br>This
+        has properties like
+        bbp/descriptor,bbp/categories,bbp/fulfillments,bbp/payments,bbp/offers,bbp/providers
+        and exp<br>This is used in the following situations.<br><ul><li>This is
+        typically used in the discovery stage when the BPP sends the details of
+        the products and services it offers as response to a search intent from
+        the BAP. </li></ul>
+      type: object
+      additionalProperties: false
+      properties:
+        descriptor:
+          $ref: "#/components/schemas/Descriptor"
+        fulfillments:
+          description: >-
+            Fulfillment modes offered at the BPP level. This is used when a BPP
+            itself offers fulfillments on behalf of the providers it has
+            onboarded.
+          type: array
+          items:
+            $ref: "#/components/schemas/Fulfillment"
+        payments:
+          description: >-
+            Payment terms offered by the BPP for all transactions. This can be
+            overriden at the provider level.
+          type: array
+          items:
+            $ref: "#/components/schemas/Payment"
+        offers:
+          description: >-
+            Offers at the BPP-level. This is common across all providers
+            onboarded by the BPP.
+          type: array
+          items:
+            $ref: "#/components/schemas/Offer"
+        providers:
+          type: array
+          items:
+            $ref: "#/components/schemas/Provider"
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagGroup"
+        exp:
+          description: Timestamp after which catalog will expire
+          type: string
+          format: date-time
+        ttl:
+          description: Duration in seconds after which this catalog will expire
+          type: string
+    Category:
+      description: A label under which a collection of items can be grouped.
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          description: ID of the category
+          type: string
+        parent_category_id:
+          $ref: "#/components/schemas/Category/properties/id"
+        descriptor:
+          $ref: "#/components/schemas/Descriptor"
+        time:
+          $ref: "#/components/schemas/Time"
+        ttl:
+          description: Time to live for an instance of this schema
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagGroup"
+    Circle:
+      description: >-
+        Describes a circular region of a specified radius centered at a
+        specified GPS coordinate.
+      type: object
+      additionalProperties: false
+      properties:
+        gps:
+          $ref: "#/components/schemas/Gps"
+        radius:
+          $ref: "#/components/schemas/Scalar"
+    City:
+      description: Describes a city
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          description: Name of the city
+          type: string
+        code:
+          description: City code
+          type: string
+    Contact:
+      description: Describes the contact information of an entity
+      type: object
+      additionalProperties: false
+      properties:
+        phone:
+          type: string
+        email:
+          type: string
+        jcard:
+          type: object
+          additionalProperties: false
+          description: A Jcard object as per draft-ietf-jcardcal-jcard-03 specification
+    Context:
+      description: >-
+        Every API call in beckn protocol has a context. It provides a high-level
+        overview to the receiver about the nature of the intended transaction.
+        Typically, it is the BAP that sets the transaction context based on the
+        consumer's location and action on their UI. But sometimes, during
+        unsolicited callbacks, the BPP also sets the transaction context but it
+        is usually the same as the context of a previous full-cycle,
+        request-callback interaction between the BAP and the BPP. The context
+        object contains four types of fields. <ol><li>Demographic information
+        about the transaction using fields like `domain`, `country`, and
+        `region`.</li><li>Addressing details like the sending and receiving
+        platform's ID and API URL.</li><li>Interoperability information like the
+        protocol version that implemented by the sender and,</li><li>Transaction
+        details like the method being called at the receiver's endpoint, the
+        transaction_id that represents an end-to-end user session at the BAP, a
+        message ID to pair requests with callbacks, a timestamp to capture
+        sending times, a ttl to specifiy the validity of the request, and a key
+        to encrypt information if necessary.</li></ol> This object must be
+        passed in every interaction between a BAP and a BPP. In HTTP/S
+        implementations, it is not necessary to send the context during the
+        synchronous response. However, in asynchronous protocols, the context
+        must be sent during all interactions,
+      type: object
+      additionalProperties: false
+      properties:
+        domain:
+          description: Domain code that is relevant to this transaction context
+          allOf:
+            - $ref: "#/components/schemas/Domain/properties/code"
+              type: string
+        location:
+          description: The location where the transaction is intended to be fulfilled.
+          allOf:
+            - $ref: "#/components/schemas/Location"
+        action:
+          description: >-
+            The Beckn protocol method being called by the sender and executed at
+            the receiver.
+          type: string
+        version:
+          type: string
+          description: Version of transaction protocol being used by the sender.
+        bap_id:
+          description: Subscriber ID of the BAP
+          allOf:
+            - description: >-
+                A globally unique identifier of the platform, Typically it is
+                the fully qualified domain name (FQDN) of the platform.
+              type: string
+        bap_uri:
+          description: Subscriber URL of the BAP for accepting callbacks from BPPs.
+          allOf:
+            - description: >-
+                The callback URL of the Subscriber. This should necessarily
+                contain the same domain name as set in `subscriber_id``.
+              type: string
+              format: uri
+        bpp_id:
+          description: Subscriber ID of the BPP
+          allOf:
+            - $ref: "#/components/schemas/Context/properties/bap_id/allOf/0"
+        bpp_uri:
+          description: Subscriber URL of the BPP for accepting calls from BAPs.
+          allOf:
+            - $ref: "#/components/schemas/Context/properties/bap_uri/allOf/0"
+        transaction_id:
+          description: >-
+            This is a unique value which persists across all API calls from
+            `search` through `confirm`. This is done to indicate an active user
+            session across multiple requests. The BPPs can use this value to
+            push personalized recommendations, and dynamic offerings related to
+            an ongoing transaction despite being unaware of the user active on
+            the BAP.
+          type: string
+          format: uuid
+        message_id:
+          description: >-
+            This is a unique value which persists during a request / callback
+            cycle. Since beckn protocol APIs are asynchronous, BAPs need a
+            common value to match an incoming callback from a BPP to an earlier
+            call. This value can also be used to ignore duplicate messages
+            coming from the BPP. It is recommended to generate a fresh
+            message_id for every new interaction. When sending unsolicited
+            callbacks, BPPs must generate a new message_id.
+          type: string
+          format: uuid
+        timestamp:
+          description: Time of request generation in RFC3339 format
+          type: string
+          format: date-time
+        key:
+          description: The encryption public key of the sender
+          type: string
+        ttl:
+          description: >-
+            The duration in ISO8601 format after timestamp for which this
+            message holds valid
+          type: string
+    Country:
+      description: Describes a country
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: Name of the country
+        code:
+          type: string
+          description: Country code as per ISO 3166-1 and ISO 3166-2 format
+    Credential:
+      description: Describes a credential of an entity - Person or Organization
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          default: VerifiableCredential
+        url:
+          description: URL of the credential
+          type: string
+          format: uri
+    Customer:
+      description: Describes a customer buying/availing a product or a service
+      type: object
+      additionalProperties: false
+      properties:
+        person:
+          $ref: "#/components/schemas/Person"
+        contact:
+          $ref: "#/components/schemas/Contact"
+    DecimalValue:
+      description: Describes a numerical value in decimal form
+      type: string
+      pattern: "[+-]?([0-9]*[.])?[0-9]+"
+    Descriptor:
+      description: Physical description of something.
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        code:
+          type: string
+        short_desc:
+          type: string
+        long_desc:
+          type: string
+        additional_desc:
+          type: object
+          additionalProperties: false
+          properties:
+            url:
+              type: string
+            content_type:
+              type: string
+              enum:
+                - text/plain
+                - text/html
+                - application/json
+        media:
+          type: array
+          items:
+            $ref: "#/components/schemas/MediaFile"
+        images:
+          type: array
+          items:
+            $ref: "#/components/schemas/Image"
+    Domain:
+      description: >-
+        Described the industry sector or sub-sector. The network policy should
+        contain codes for all the industry sectors supported by the network.
+        Domains can be created in varying levels of granularity. The granularity
+        of a domain can be decided by the participants of the network. Too broad
+        domains will result in irrelevant search broadcast calls to BPPs that
+        don't have services supporting the domain. Too narrow domains will
+        result in a large number of registry entries for each BPP. It is
+        recommended that network facilitators actively collaborate with various
+        working groups and network participants to carefully choose domain codes
+        keeping in mind relevance, performance, and opportunity cost. It is
+        recommended that networks choose broad domains like mobility, logistics,
+        healthcare etc, and progressively granularize them as and when the
+        number of network participants for each domain grows large.
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          description: Name of the domain
+          type: string
+        code:
+          description: >-
+            Standard code representing the domain. The standard is usually
+            published as part of the network policy. Furthermore, the network
+            facilitator should also provide a mechanism to provide the supported
+            domains of a network.
+        additional_info:
+          description: A url that contains addtional information about that domain.
+          allOf:
+            - $ref: "#/components/schemas/MediaFile"
+    Duration:
+      description: Describes duration as per ISO8601 format
+      type: string
+    Error:
+      description: >-
+        Describes an error object that is returned by a BAP, BPP or BG as a
+        response or callback to an action by another network participant. This
+        object is sent when any request received by a network participant is
+        unacceptable. This object can be sent either during Ack or with the
+        callback.
+      type: object
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+          description: >-
+            Standard error code. For full list of error codes, refer to
+            docs/protocol-drafts/BECKN-005-ERROR-CODES-DRAFT-01.md of this repo"
+        paths:
+          type: string
+          description: >-
+            Path to json schema generating the error. Used only during json
+            schema validation errors
+        message:
+          type: string
+          description: >-
+            Human readable message describing the error. Used mainly for
+            logging. Not recommended to be shown to the user.
+    Fee:
+      description: A fee applied on a particular entity
+      type: object
+      additionalProperties: false
+      properties:
+        percentage:
+          description: Percentage of a value
+          allOf:
+            - $ref: "#/components/schemas/DecimalValue"
+        amount:
+          description: A fixed value
+          allOf:
+            - $ref: "#/components/schemas/Price"
+    Form:
+      description: Describes a form
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          description: The form identifier.
+          type: string
+        url:
+          description: >-
+            The URL from where the form can be fetched. The content fetched from
+            the url must be processed as per the mime_type specified in this
+            object. Once fetched, the rendering platform can choosed to render
+            the form as-is as an embeddable element; or process it further to
+            blend with the theme of the application. In case the interface is
+            non-visual, the the render can process the form data and reproduce
+            it as per the standard specified in the form.
+          type: string
+          format: uri
+        data:
+          description: The form submission data
+          type: object
+          additionalProperties:
+            type: string
+        mime_type:
+          description: >-
+            This field indicates the nature and format of the form received by
+            querying the url. MIME types are defined and standardized in IETF's
+            RFC 6838.
+          type: string
+          enum:
+            - text/html
+            - application/html
+            - application/xml
+        resubmit:
+          type: boolean
+        multiple_sumbissions:
+          type: boolean
+    Fulfillment:
+      description: Describes how a an order will be rendered/fulfilled to the end-customer
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          description: Unique reference ID to the fulfillment of an order
+          type: string
+        type:
+          description: >-
+            A code that describes the mode of fulfillment. This is typically set
+            when there are multiple ways an order can be fulfilled. For example,
+            a retail order can be fulfilled either via store pickup or a home
+            delivery. Similarly, a medical consultation can be provided either
+            in-person or via tele-consultation. The network policy must publish
+            standard fulfillment type codes for the different modes of
+            fulfillment.
+          type: string
+        rateable:
+          description: Whether the fulfillment can be rated or not
+          type: boolean
+        rating:
+          description: The rating value of the fulfullment service.
+          allOf:
+            - $ref: "#/components/schemas/Rating/properties/value"
+        state:
+          description: >-
+            The current state of fulfillment. The BPP must set this value
+            whenever the state of the order fulfillment changes and fire an
+            unsolicited `on_status` call.
+          allOf:
+            - $ref: "#/components/schemas/FulfillmentState"
+        tracking:
+          type: boolean
+          description: Indicates whether the fulfillment allows tracking
+          default: false
+        customer:
+          description: The person that will ultimately receive the order
+          allOf:
+            - $ref: "#/components/schemas/Customer"
+        agent:
+          description: The agent that is currently handling the fulfillment of the order
+          allOf:
+            - $ref: "#/components/schemas/Agent"
+        contact:
+          $ref: "#/components/schemas/Contact"
+        vehicle:
+          $ref: "#/components/schemas/Vehicle"
+        stops:
+          description: >-
+            The list of logical stops encountered during the fulfillment of an
+            order.
+          type: array
+          items:
+            $ref: "#/components/schemas/Stop"
+        path:
+          description: >-
+            The physical path taken by the agent that can be rendered on a map.
+            The allowed format of this property can be set by the network.
+          type: string
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagGroup"
+    FulfillmentState:
+      description: Describes the state of fulfillment
+      type: object
+      additionalProperties: false
+      properties:
+        descriptor:
+          $ref: "#/components/schemas/Descriptor"
+        updated_at:
+          type: string
+          format: date-time
+        updated_by:
+          type: string
+          description: ID of entity which changed the state
+    Gps:
+      description: Describes a GPS coordinate
+      type: string
+      pattern: >-
+        ^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$
+    Image:
+      description: Describes an image
+      type: object
+      additionalProperties: false
+      properties:
+        url:
+          description: URL to the image. This can be a data url or an remote url
+          type: string
+          format: uri
+        size_type:
+          description: >-
+            The size of the image. The network policy can define the default
+            dimensions of each type
+          type: string
+          enum:
+            - xs
+            - sm
+            - md
+            - lg
+            - xl
+            - custom
+        width:
+          description: Width of the image in pixels
+          type: string
+        height:
+          description: Height of the image in pixels
+          type: string
+    Intent:
+      description: >-
+        The intent to buy or avail a product or a service. The BAP can declare
+        the intent of the consumer containing <ul><li>What they want (A product,
+        service, offer)</li><li>Who they want (A seller, service provider, agent
+        etc)</li><li>Where they want it and where they want it from</li><li>When
+        they want it (start and end time of fulfillment</li><li>How they want to
+        pay for it</li></ul><br>This has properties like
+        descriptor,provider,fulfillment,payment,category,offer,item,tags<br>This
+        is typically used by the BAP to send the purpose of the user's search to
+        the BPP. This will be used by the BPP to find products or services it
+        offers that may match the user's intent.<br>For example, in Mobility,
+        the mobility consumer declares a mobility intent. In this case, the
+        mobility consumer declares information that describes various aspects of
+        their journey like,<ul><li>Where would they like to begin their journey
+        (intent.fulfillment.start.location)</li><li>Where would they like to end
+        their journey (intent.fulfillment.end.location)</li><li>When would they
+        like to begin their journey (intent.fulfillment.start.time)</li><li>When
+        would they like to end their journey
+        (intent.fulfillment.end.time)</li><li>Who is the transport service
+        provider they would like to avail services from
+        (intent.provider)</li><li>Who is traveling (This is not recommended in
+        public networks) (intent.fulfillment.customer)</li><li>What kind of fare
+        product would they like to purchase (intent.item)</li><li>What add-on
+        services would they like to avail</li><li>What offers would they like to
+        apply on their booking (intent.offer)</li><li>What category of services
+        would they like to avail (intent.category)</li><li>What additional
+        luggage are they carrying</li><li>How would they like to pay for their
+        journey (intent.payment)</li></ul><br>For example, in health domain, a
+        consumer declares the intent for a lab booking the describes various
+        aspects of their booking like,<ul><li>Where would they like to get their
+        scan/test done (intent.fulfillment.start.location)</li><li>When would
+        they like to get their scan/test done
+        (intent.fulfillment.start.time)</li><li>When would they like to get the
+        results of their test/scan (intent.fulfillment.end.time)</li><li>Who is
+        the service provider they would like to avail services from
+        (intent.provider)</li><li>Who is getting the test/scan
+        (intent.fulfillment.customer)</li><li>What kind of test/scan would they
+        like to purchase (intent.item)</li><li>What category of services would
+        they like to avail (intent.category)</li><li>How would they like to pay
+        for their journey (intent.payment)</li></ul>
+      type: object
+      additionalProperties: false
+      properties:
+        descriptor:
+          description: >-
+            A raw description of the search intent. Free text search strings,
+            raw audio, etc can be sent in this object.
+          allOf:
+            - $ref: "#/components/schemas/Descriptor"
+        provider:
+          description: >-
+            The provider from which the customer wants to place to the order
+            from
+          allOf:
+            - $ref: "#/components/schemas/Provider"
+        fulfillment:
+          description: Details on how the customer wants their order fulfilled
+          allOf:
+            - $ref: "#/components/schemas/Fulfillment"
+        payment:
+          description: Details on how the customer wants to pay for the order
+          allOf:
+            - $ref: "#/components/schemas/Payment"
+        category:
+          description: Details on the item category
+          allOf:
+            - $ref: "#/components/schemas/Category"
+        offer:
+          description: details on the offer the customer wants to avail
+          allOf:
+            - $ref: "#/components/schemas/Offer"
+        item:
+          description: Details of the item that the consumer wants to order
+          allOf:
+            - $ref: "#/components/schemas/Item"
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagGroup"
+    ItemQuantity:
+      description: Describes the count or amount of an item
+      type: object
+      additionalProperties: false
+      properties:
+        allocated:
+          description: >-
+            This represents the exact quantity allocated for purchase of the
+            item.
+          type: object
+          additionalProperties: false
+          properties:
+            count:
+              type: integer
+              minimum: 0
+            measure:
+              $ref: "#/components/schemas/Scalar"
+        available:
+          description: >-
+            This represents the exact quantity available for purchase of the
+            item. The buyer can only purchase multiples of this
+          type: object
+          additionalProperties: false
+          properties:
+            count:
+              type: integer
+              minimum: 0
+            measure:
+              $ref: "#/components/schemas/Scalar"
+        maximum:
+          description: >-
+            This represents the maximum quantity allowed for purchase of the
+            item
+          type: object
+          additionalProperties: false
+          properties:
+            count:
+              type: integer
+              minimum: 1
+            measure:
+              $ref: "#/components/schemas/Scalar"
+        minimum:
+          description: >-
+            This represents the minimum quantity allowed for purchase of the
+            item
+          type: object
+          additionalProperties: false
+          properties:
+            count:
+              type: integer
+              minimum: 0
+            measure:
+              $ref: "#/components/schemas/Scalar"
+        selected:
+          description: This represents the quantity selected for purchase of the item
+          type: object
+          additionalProperties: false
+          properties:
+            count:
+              type: integer
+              minimum: 0
+            measure:
+              $ref: "#/components/schemas/Scalar"
+        unitized:
+          description: This represents the quantity available in a single unit of the item
+          type: object
+          additionalProperties: false
+          properties:
+            count:
+              type: integer
+              minimum: 1
+              maximum: 1
+            measure:
+              $ref: "#/components/schemas/Scalar"
+    Item:
+      description: >-
+        Describes a product or a service offered to the end consumer by the
+        provider. In the mobility sector, it can represent a fare product like
+        one way journey. In the logistics sector, it can represent the delivery
+        service offering. In the retail domain it can represent a product like a
+        grocery item.
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          description: ID of the item.
+          type: string
+        parent_item_id:
+          description: ID of the item, this item is a variant of
+          allOf:
+            - $ref: "#/components/schemas/Item/properties/id"
+        parent_item_quantity:
+          description: The number of units of the parent item this item is a multiple of
+          allOf:
+            - $ref: "#/components/schemas/ItemQuantity"
+        descriptor:
+          description: Physical description of the item
+          allOf:
+            - $ref: "#/components/schemas/Descriptor"
+        creator:
+          description: The creator of this item
+          allOf:
+            - $ref: "#/components/schemas/Organization"
+        price:
+          description: The price of this item, if it has intrinsic value
+          allOf:
+            - $ref: "#/components/schemas/Price"
+        quantity:
+          description: The selling quantity of the item
+          allOf:
+            - $ref: "#/components/schemas/ItemQuantity"
+        category_ids:
+          description: Categories this item can be listed under
+          type: array
+          items:
+            allOf:
+              - $ref: "#/components/schemas/Category/properties/id"
+        fulfillment_ids:
+          description: Modes through which this item can be fulfilled
+          type: array
+          items:
+            allOf:
+              - $ref: "#/components/schemas/Fulfillment/properties/id"
+        location_ids:
+          description: Provider Locations this item is available in
+          type: array
+          items:
+            allOf:
+              - $ref: "#/components/schemas/Location/properties/id"
+        payment_ids:
+          description: Payment modalities through which this item can be ordered
+          type: array
+          items:
+            allOf:
+              - $ref: "#/components/schemas/Payment/properties/id"
+        add_ons:
+          type: array
+          items:
+            $ref: "#/components/schemas/AddOn"
+        cancellation_terms:
+          description: Cancellation terms of this item
+          type: array
+          items:
+            $ref: "#/components/schemas/CancellationTerm"
+        refund_terms:
+          description: Refund terms of this item
+          type: array
+          items:
+            description: Refund term of an item or an order
+            type: object
+            additionalProperties: false
+            properties:
+              fulfillment_state:
+                description: The state of fulfillment during which this term is applicable.
+                allOf:
+                  - $ref: "#/components/schemas/State"
+              refund_eligible:
+                description: Indicates if cancellation will result in a refund
+                type: boolean
+              refund_within:
+                description: >-
+                  Time within which refund will be processed after successful
+                  cancellation.
+                allOf:
+                  - $ref: "#/components/schemas/Time"
+              refund_amount:
+                $ref: "#/components/schemas/Price"
+        replacement_terms:
+          description: Terms that are applicable be met when this item is replaced
+          type: array
+          items:
+            $ref: "#/components/schemas/ReplacementTerm"
+        return_terms:
+          description: Terms that are applicable when this item is returned
+          type: array
+          items:
+            $ref: "#/components/schemas/ReturnTerm"
+        xinput:
+          description: >-
+            Additional input required from the customer to purchase / avail this
+            item
+          allOf:
+            - $ref: "#/components/schemas/XInput"
+        time:
+          description: >-
+            Temporal attributes of this item. This property is used when the
+            item exists on the catalog only for a limited period of time.
+          allOf:
+            - $ref: "#/components/schemas/Time"
+        rateable:
+          description: Whether this item can be rated
+          type: boolean
+        rating:
+          description: The rating of the item
+          allOf:
+            - $ref: "#/components/schemas/Rating/properties/value"
+        matched:
+          description: Whether this item is an exact match of the request
+          type: boolean
+        related:
+          description: Whether this item is a related item to the exactly matched item
+          type: boolean
+        recommended:
+          description: Whether this item is a recommended item to a response
+          type: boolean
+        ttl:
+          description: Time to live in seconds for an instance of this schema
+          type: string
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagGroup"
+    Location:
+      description: The physical location of something
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        descriptor:
+          $ref: "#/components/schemas/Descriptor"
+        map_url:
+          description: >-
+            The url to the map of the location. This can be a globally
+            recognized map url or the one specified by the network policy.
+          type: string
+          format: uri
+        gps:
+          description: The GPS co-ordinates of this location.
+          allOf:
+            - $ref: "#/components/schemas/Gps"
+        updated_at:
+          type: string
+          format: date-time
+        address:
+          description: The address of this location.
+          allOf:
+            - $ref: "#/components/schemas/Address"
+        city:
+          description: The city this location is, or is located within
+          allOf:
+            - $ref: "#/components/schemas/City"
+        district:
+          description: The state this location is, or is located within
+          type: string
+        state:
+          description: The state this location is, or is located within
+          allOf:
+            - $ref: "#/components/schemas/State"
+        country:
+          description: The country this location is, or is located within
+          allOf:
+            - $ref: "#/components/schemas/Country"
+        area_code:
+          type: string
+        circle:
+          $ref: "#/components/schemas/Circle"
+        polygon:
+          description: The boundary polygon of this location
+          type: string
+        3dspace:
+          description: The three dimensional region describing this location
+          type: string
+        rating:
+          description: The rating of this location
+          allOf:
+            - $ref: "#/components/schemas/Rating/properties/value"
+    MediaFile:
+      description: This object contains a url to a media file.
+      type: object
+      additionalProperties: false
+      properties:
+        mimetype:
+          description: >-
+            indicates the nature and format of the document, file, or assortment
+            of bytes. MIME types are defined and standardized in IETF's RFC 6838
+          type: string
+        url:
+          description: The URL of the file
+          type: string
+          format: uri
+        signature:
+          description: The digital signature of the file signed by the sender
+          type: string
+        dsa:
+          description: The signing algorithm used by the sender
+          type: string
+    Offer:
+      description: >-
+        An offer associated with a catalog. This is typically used to promote a
+        particular product and enable more purchases.
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        descriptor:
+          $ref: "#/components/schemas/Descriptor"
+        location_ids:
+          type: array
+          items:
+            $ref: "#/components/schemas/Location/properties/id"
+        category_ids:
+          type: array
+          items:
+            $ref: "#/components/schemas/Category/properties/id"
+        item_ids:
+          type: array
+          items:
+            $ref: "#/components/schemas/Item/properties/id"
+        time:
+          $ref: "#/components/schemas/Time"
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagGroup"
+    Option:
+      description: Describes a selectable option
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        descriptor:
+          $ref: "#/components/schemas/Descriptor"
+    Order:
+      description: >-
+        Describes a legal purchase order. It contains the complete details of
+        the legal contract created between the buyer and the seller.
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: >-
+            Human-readable ID of the order. This is generated at the BPP layer.
+            The BPP can either generate order id within its system or forward
+            the order ID created at the provider level.
+        ref_order_ids:
+          description: A list of order IDs to link this order to previous orders.
+          type: array
+          items:
+            type: string
+            description: ID of a previous order
+        status:
+          description: >-
+            Status of the order. Allowed values can be defined by the network
+            policy
+          type: string
+          enum:
+            - ACTIVE
+            - COMPLETE
+            - CANCELLED
+            - COMPLETED
+            - SOFT_CANCEL
+            - CANCELLATION_INITIATED
+            - CANCELLATION_REJECTED
+        type:
+          description: >-
+            This is used to indicate the type of order being created to BPPs.
+            Sometimes orders can be linked to previous orders, like a
+            replacement order in a retail domain. A follow-up consultation in
+            healthcare domain. A single order part of a subscription order. The
+            list of order types can be standardized at the network level.
+          type: string
+          default: DEFAULT
+          enum:
+            - DRAFT
+            - DEFAULT
+        provider:
+          description: Details of the provider whose catalog items have been selected.
+          allOf:
+            - $ref: "#/components/schemas/Provider"
+        items:
+          description: The items purchased / availed in this order
+          type: array
+          items:
+            $ref: "#/components/schemas/Item"
+        add_ons:
+          description: The add-ons purchased / availed in this order
+          type: array
+          items:
+            $ref: "#/components/schemas/AddOn"
+        offers:
+          description: The offers applied in this order
+          type: array
+          items:
+            $ref: "#/components/schemas/Offer"
+        billing:
+          description: The billing details of this order
+          allOf:
+            - $ref: "#/components/schemas/Billing"
+        fulfillments:
+          description: The fulfillments involved in completing this order
+          type: array
+          items:
+            $ref: "#/components/schemas/Fulfillment"
+        cancellation:
+          description: The cancellation details of this order
+          allOf:
+            - $ref: "#/components/schemas/Cancellation"
+        cancellation_terms:
+          description: Cancellation terms of this item
+          type: array
+          items:
+            $ref: "#/components/schemas/CancellationTerm"
+        documents:
+          type: array
+          items:
+            description: Documnents associated to the order
+            type: object
+            additionalProperties: false
+            properties:
+              descriptor:
+                $ref: "#/components/schemas/Descriptor"
+              mime_type:
+                description: >-
+                  This field indicates the nature and format of the form
+                  received by querying the url. MIME types are defined and
+                  standardized in IETF's RFC 6838.
+                type: string
+                enum:
+                  - text/html
+                  - application/html
+                  - application/xml
+                  - application/pdf
+              url:
+                description: >-
+                  The URL from where the form can be fetched. The content
+                  fetched from the url must be processed as per the mime_type
+                  specified in this object.
+                type: string
+                format: uri
+        refund_terms:
+          description: Refund terms of this item
+          type: array
+          items:
+            $ref: "#/components/schemas/Item/properties/refund_terms/items"
+        replacement_terms:
+          description: Replacement terms of this item
+          type: array
+          items:
+            $ref: "#/components/schemas/ReplacementTerm"
+        return_terms:
+          description: Return terms of this item
+          type: array
+          items:
+            $ref: "#/components/schemas/ReturnTerm"
+        quote:
+          description: The mutually agreed upon quotation for this order.
+          allOf:
+            - $ref: "#/components/schemas/Quotation"
+        payments:
+          description: The terms of settlement for this order
+          type: array
+          items:
+            $ref: "#/components/schemas/Payment"
+        created_at:
+          description: The date-time of creation of this order
+          type: string
+          format: date-time
+        updated_at:
+          description: The date-time of updated of this order
+          type: string
+          format: date-time
+        xinput:
+          description: Additional input required from the customer to confirm this order
+          allOf:
+            - $ref: "#/components/schemas/XInput"
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagGroup"
+    Organization:
+      description: An organization. Usually a recognized business entity.
+      type: object
+      additionalProperties: false
+      properties:
+        descriptor:
+          $ref: "#/components/schemas/Descriptor"
+        address:
+          description: The postal address of the organization
+          allOf:
+            - $ref: "#/components/schemas/Address"
+        state:
+          description: The state where the organization's address is registered
+          allOf:
+            - $ref: "#/components/schemas/State"
+        city:
+          description: The city where the the organization's address is registered
+          allOf:
+            - $ref: "#/components/schemas/City"
+        contact:
+          $ref: "#/components/schemas/Contact"
+    Payment:
+      description: >-
+        Describes the terms of settlement between the BAP and the BPP for a
+        single transaction. When instantiated, this object contains <ol><li>the
+        amount that has to be settled,</li><li>The payment destination
+        destination details</li><li>When the settlement should happen,
+        and</li><li>A transaction reference ID</li></ol>. During a transaction,
+        the BPP reserves the right to decide the terms of payment. However, the
+        BAP can send its terms to the BPP first. If the BPP does not agree to
+        those terms, it must overwrite the terms and return them to the BAP. If
+        overridden, the BAP must either agree to the terms sent by the BPP in
+        order to preserve the provider's autonomy, or abort the transaction. In
+        case of such disagreements, the BAP and the BPP can perform offline
+        negotiations on the payment terms. Once an agreement is reached, the BAP
+        and BPP can resume transactions.
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          description: >-
+            ID of the payment term that can be referred at an item or an order
+            level in a catalog
+          type: string
+        collected_by:
+          description: >-
+            This field indicates who is the collector of payment. The BAP can
+            set this value to 'bap' if it wants to collect the payment first
+            and  settle it to the BPP. If the BPP agrees to those terms, the BPP
+            should not send the payment url. Alternatively, the BPP can set this
+            field with the value 'bpp' if it wants the payment to be made
+            directly.
+          type: string
+        url:
+          type: string
+          description: >-
+            A payment url to be called by the BAP. If empty, then the payment is
+            to be done offline. The details of payment should be present in the
+            params object. If tl_method = http/get, then the payment details
+            will be sent as url params. Two url param values,
+            ```$transaction_id``` and ```$amount``` are mandatory.
+          format: uri
+        tl_method:
+          type: string
+        params:
+          type: object
+          additionalProperties: false
+          properties:
+            transaction_id:
+              type: string
+              description: The reference transaction ID associated with a payment activity
+            amount:
+              type: string
+            currency:
+              type: string
+            bank_code:
+              type: string
+            bank_account_number:
+              type: string
+            virtual_payment_address:
+              type: string
+            source_bank_code:
+              type: string
+            source_bank_account_number:
+              type: string
+            source_virtual_payment_address:
+              type: string
+        type:
+          type: string
+          enum:
+            - PRE-ORDER
+            - PRE-FULFILLMENT
+            - ON-FULFILLMENT
+            - POST-FULFILLMENT
+            - ON-ORDER
+            - PART-PAYMENT
+        status:
+          type: string
+          enum:
+            - PAID
+            - NOT-PAID
+        time:
+          $ref: "#/components/schemas/Time"
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagGroup"
+    Person:
+      description: Describes a person as any individual
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: Describes the identity of the person
+        url:
+          description: Profile url of the person
+          type: string
+          format: uri
+        name:
+          description: the name of the person
+          type: string
+        image:
+          $ref: "#/components/schemas/Image"
+        age:
+          description: Age of the person
+          allOf:
+            - $ref: "#/components/schemas/Duration"
+        dob:
+          description: Date of birth of the person
+          type: string
+          format: date
+        gender:
+          type: string
+          description: >-
+            Gender of something, typically a Person, but possibly also fictional
+            characters, animals, etc. While Male and Female may be used, text
+            strings are also acceptable for people who do not identify as a
+            binary gender.Allowed values for this field can be published in the
+            network policy
+        creds:
+          type: array
+          items:
+            $ref: "#/components/schemas/Credential"
+        languages:
+          type: array
+          items:
+            description: Describes a language known to the person.
+            type: object
+            additionalProperties: false
+            properties:
+              code:
+                type: string
+              name:
+                type: string
+        skills:
+          type: array
+          items:
+            description: Describes a skill of the person.
+            type: object
+            additionalProperties: false
+            properties:
+              code:
+                type: string
+              name:
+                type: string
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagGroup"
+    Price:
+      description: Describes the price of a product or service
+      type: object
+      additionalProperties: false
+      properties:
+        currency:
+          type: string
+        value:
+          $ref: "#/components/schemas/DecimalValue"
+        estimated_value:
+          $ref: "#/components/schemas/DecimalValue"
+        computed_value:
+          $ref: "#/components/schemas/DecimalValue"
+        listed_value:
+          $ref: "#/components/schemas/DecimalValue"
+        offered_value:
+          $ref: "#/components/schemas/DecimalValue"
+        minimum_value:
+          $ref: "#/components/schemas/DecimalValue"
+        maximum_value:
+          $ref: "#/components/schemas/DecimalValue"
+    Provider:
+      description: Describes the catalog of a business.
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: Id of the provider
+        descriptor:
+          $ref: "#/components/schemas/Descriptor"
+        category_id:
+          type: string
+          description: Category Id of the provider at the BPP-level catalog
+        rating:
+          $ref: "#/components/schemas/Rating/properties/value"
+        time:
+          $ref: "#/components/schemas/Time"
+        categories:
+          type: array
+          items:
+            $ref: "#/components/schemas/Category"
+        fulfillments:
+          type: array
+          items:
+            $ref: "#/components/schemas/Fulfillment"
+        payments:
+          type: array
+          items:
+            $ref: "#/components/schemas/Payment"
+        locations:
+          type: array
+          items:
+            $ref: "#/components/schemas/Location"
+        offers:
+          type: array
+          items:
+            $ref: "#/components/schemas/Offer"
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Item"
+        exp:
+          type: string
+          description: Time after which catalog has to be refreshed
+          format: date-time
+        rateable:
+          description: Whether this provider can be rated or not
+          type: boolean
+        ttl:
+          description: >-
+            The time-to-live in seconds, for this object. This can be overriden
+            at deeper levels. A value of -1 indicates that this object is not
+            cacheable.
+          type: string
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagGroup"
+    Quotation:
+      description: >-
+        Describes a quote. It is the estimated price of products or services
+        from the BPP.<br>This has properties like price, breakup, ttl
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          description: ID of the quote.
+          type: string
+          format: uuid
+        price:
+          description: The total quoted price
+          allOf:
+            - $ref: "#/components/schemas/Price"
+        breakup:
+          description: the breakup of the total quoted price
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              item:
+                $ref: "#/components/schemas/Item"
+              title:
+                type: string
+              price:
+                $ref: "#/components/schemas/Price"
+        ttl:
+          $ref: "#/components/schemas/Duration"
+    Rating:
+      description: Describes the rating of an entity
+      type: object
+      additionalProperties: false
+      properties:
+        rating_category:
+          description: Category of the entity being rated
+          type: string
+          enum:
+            - Item
+            - Order
+            - Fulfillment
+            - Provider
+            - Agent
+            - Support
+        id:
+          description: Id of the object being rated
+          type: string
+        value:
+          description: >-
+            Rating value given to the object. This can be a single value or can
+            also contain an inequality operator like gt, gte, lt, lte. This can
+            also contain an inequality expression containing logical operators
+            like && and ||.
+          type: string
+    Region:
+      description: >-
+        Describes an arbitrary region of space. The network policy should
+        contain a published list of supported regions by the network.
+      type: object
+      additionalProperties: false
+      properties:
+        dimensions:
+          description: >-
+            The number of dimensions that are used to describe any point inside
+            that region. The most common dimensionality of a region is 2, that
+            represents an area on a map. There are regions on the map that can
+            be approximated to one-dimensional regions like roads, railway
+            lines, or shipping lines. 3 dimensional regions are rarer, but are
+            gaining popularity as flying drones are being adopted for various
+            fulfillment services.
+          type: string
+          enum:
+            - "1"
+            - "2"
+            - "3"
+        type:
+          description: >-
+            The type of region. This is used to specify the granularity of the
+            region represented by this object. Various examples of
+            two-dimensional region types are city, country, state, district, and
+            so on. The network policy should contain a list of all possible
+            region types supported by the network.
+          type: string
+        name:
+          type: string
+          description: Name of the region as specified on the map where that region exists.
+        code:
+          type: string
+          description: >-
+            A standard code representing the region. This should be interpreted
+            in the same way by all network participants.
+        boundary:
+          type: string
+          description: >-
+            A string representing the boundary of the region. One-dimensional
+            regions are represented by polylines. Two-dimensional regions are
+            represented by polygons, and three-dimensional regions can
+            represented by polyhedra.
+        map_url:
+          type: string
+          description: >-
+            The url to the map of the region. This can be a globally recognized
+            map or the one specified by the network policy.
+    ReplacementTerm:
+      description: The replacement policy of an item or an order
+      type: object
+      additionalProperties: false
+      properties:
+        fulfillment_state:
+          description: The state of fulfillment during which this term is applicable.
+          allOf:
+            - $ref: "#/components/schemas/State"
+        replace_within:
+          description: >-
+            Applicable only for buyer managed returns where the buyer has to
+            replace the item before a certain date-time, failing which they will
+            not be eligible for replacement
+          allOf:
+            - $ref: "#/components/schemas/Time"
+        external_ref:
+          $ref: "#/components/schemas/MediaFile"
+    ReturnTerm:
+      description: Describes the return policy of an item or an order
+      type: object
+      additionalProperties: false
+      properties:
+        fulfillment_state:
+          description: The state of fulfillment during which this term IETF''s applicable.
+          allOf:
+            - $ref: "#/components/schemas/State"
+        return_eligible:
+          description: Indicates whether the item is eligible for return
+          type: boolean
+        return_time:
+          description: >-
+            Applicable only for buyer managed returns where the buyer has to
+            return the item to the origin before a certain date-time, failing
+            which they will not be eligible for refund.
+          allOf:
+            - $ref: "#/components/schemas/Time"
+        return_location:
+          description: The location where the item or order must / will be returned to
+          allOf:
+            - $ref: "#/components/schemas/Location"
+        fulfillment_managed_by:
+          description: The entity that will perform the return
+          type: string
+          enum:
+            - CONSUMER
+            - PROVIDER
+    Scalar:
+      description: Describes a scalar
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          enum:
+            - CONSTANT
+            - VARIABLE
+        value:
+          $ref: "#/components/schemas/DecimalValue"
+        estimated_value:
+          $ref: "#/components/schemas/DecimalValue"
+        computed_value:
+          $ref: "#/components/schemas/DecimalValue"
+        range:
+          type: object
+          additionalProperties: false
+          properties:
+            min:
+              $ref: "#/components/schemas/DecimalValue"
+            max:
+              $ref: "#/components/schemas/DecimalValue"
+        unit:
+          type: string
+    Schedule:
+      description: >-
+        Describes schedule as a repeating time period used to describe a
+        regularly recurring event. At a minimum a schedule will specify
+        frequency which describes the interval between occurrences of the event.
+        Additional information can be provided to specify the schedule more
+        precisely. This includes identifying the timestamps(s) of when the event
+        will take place. Schedules may also have holidays to exclude a specific
+        day from the schedule.<br>This has properties like frequency, holidays,
+        times
+      type: object
+      additionalProperties: false
+      properties:
+        frequency:
+          $ref: "#/components/schemas/Duration"
+        holidays:
+          type: array
+          items:
+            type: string
+            format: date-time
+        times:
+          type: array
+          items:
+            type: string
+            format: date-time
+    State:
+      description: A bounded geopolitical region of governance inside a country.
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: Name of the state
+        code:
+          type: string
+          description: State code as per country or international standards
+    Stop:
+      description: A logical point in space and time during the fulfillment of an order.
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        parent_stop_id:
+          type: string
+        location:
+          description: Location of the stop
+          allOf:
+            - $ref: "#/components/schemas/Location"
+        type:
+          description: >-
+            The type of stop. Allowed values of this property can be defined by
+            the network policy.
+          type: string
+        time:
+          description: Timings applicable at the stop.
+          allOf:
+            - $ref: "#/components/schemas/Time"
+        instructions:
+          description: Instructions that need to be followed at the stop
+          allOf:
+            - $ref: "#/components/schemas/Descriptor"
+        contact:
+          description: Contact details of the stop
+          allOf:
+            - $ref: "#/components/schemas/Contact"
+        person:
+          description: The details of the person present at the stop
+          allOf:
+            - $ref: "#/components/schemas/Person"
+        authorization:
+          $ref: "#/components/schemas/Authorization"
+    Support:
+      description: Details of customer support
+      type: object
+      additionalProperties: false
+      properties:
+        ref_id:
+          type: string
+        callback_phone:
+          type: string
+          format: phone
+        phone:
+          type: string
+          format: phone
+        email:
+          type: string
+          format: email
+        url:
+          type: string
+          format: uri
+    Tag:
+      description: >-
+        Describes a tag. This is used to contain extended metadata. This object
+        can be added as a property to any schema to describe extended
+        attributes. For BAPs, tags can be sent during search to optimize and
+        filter search results. BPPs can use tags to index their catalog to allow
+        better search functionality. Tags are sent by the BPP as part of the
+        catalog response in the `on_search` callback. Tags are also meant for
+        display purposes. Upon receiving a tag, BAPs are meant to render them as
+        name-value pairs. This is particularly useful when rendering tabular
+        information about a product or service.
+      type: object
+      additionalProperties: false
+      properties:
+        descriptor:
+          description: Description of the Tag, can be used to store detailed information.
+          allOf:
+            - $ref: "#/components/schemas/Descriptor"
+        value:
+          description: >-
+            The value of the tag. This set by the BPP and rendered as-is by the
+            BAP.
+          type: string
+        display:
+          description: >-
+            This value indicates if the tag is intended for display purposes. If
+            set to `true`, then this tag must be displayed. If it is set to
+            `false`, it should not be displayed. This value can override the
+            group display value.
+          type: boolean
+    TagGroup:
+      description: >-
+        A collection of tag objects with group level attributes. For detailed
+        documentation on the Tags and Tag Groups schema go to
+        https://github.com/beckn/protocol-specifications/discussions/316
+      type: object
+      additionalProperties: false
+      properties:
+        display:
+          description: >-
+            Indicates the display properties of the tag group. If display is set
+            to false, then the group will not be displayed. If it is set to
+            true, it should be displayed. However, group-level display
+            properties can be overriden by individual tag-level display
+            property. As this schema is purely for catalog display purposes, it
+            is not recommended to send this value during search.
+          type: boolean
+          default: true
+        descriptor:
+          description: >-
+            Description of the TagGroup, can be used to store detailed
+            information.
+          allOf:
+            - $ref: "#/components/schemas/Descriptor"
+        list:
+          description: >-
+            An array of Tag objects listed under this group. This property can
+            be set by BAPs during search to narrow the `search` and achieve more
+            relevant results. When received during `on_search`, BAPs must render
+            this list under the heading described by the `name` property of this
+            schema.
+          type: array
+          items:
+            $ref: "#/components/schemas/Tag"
+    Time:
+      description: >-
+        Describes time in its various forms. It can be a single point in time;
+        duration; or a structured timetable of operations<br>This has properties
+        like label, time stamp,duration,range, days, schedule
+      type: object
+      additionalProperties: false
+      properties:
+        label:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        duration:
+          $ref: "#/components/schemas/Duration"
+        range:
+          type: object
+          additionalProperties: false
+          properties:
+            start:
+              type: string
+              format: date-time
+            end:
+              type: string
+              format: date-time
+        days:
+          type: string
+          description: comma separated values representing days of the week
+        schedule:
+          $ref: "#/components/schemas/Schedule"
+    Tracking:
+      description: >-
+        Contains tracking information that can be used by the BAP to track the
+        fulfillment of an order in real-time. which is useful for knowing the
+        location of time sensitive deliveries.
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          description: A unique tracking reference number
+          type: string
+        url:
+          description: >-
+            A URL to the tracking endpoint. This can be a link to a tracking
+            webpage, a webhook URL created by the BAP where BPP can push the
+            tracking data, or a GET url creaed by the BPP which the BAP can poll
+            to get the tracking data. It can also be a websocket URL where the
+            BPP can push real-time tracking data.
+          type: string
+          format: uri
+        location:
+          description: >-
+            In case there is no real-time tracking endpoint available, this
+            field will contain the latest location of the entity being tracked.
+            The BPP will update this value everytime the BAP calls the track
+            API.
+          allOf:
+            - $ref: "#/components/schemas/Location"
+        status:
+          description: >-
+            This value indicates if the tracking is currently active or not. If
+            this value is `active`, then the BAP can begin tracking the order.
+            If this value is `inactive`, the tracking URL is considered to be
+            expired and the BAP should stop tracking the order.
+          type: string
+          enum:
+            - active
+            - inactive
+    Vehicle:
+      description: >-
+        Describes a vehicle is a device that is designed or used to transport
+        people or cargo over land, water, air, or through space.<br>This has
+        properties like category, capacity, make, model,
+        size,variant,color,energy_type,registration
+      type: object
+      additionalProperties: false
+      properties:
+        category:
+          type: string
+        capacity:
+          type: integer
+        make:
+          type: string
+        model:
+          type: string
+        size:
+          type: string
+        variant:
+          type: string
+        color:
+          type: string
+        energy_type:
+          type: string
+        registration:
+          type: string
+        wheels_count:
+          type: string
+        cargo_volumne:
+          type: string
+        wheelchair_access:
+          type: string
+        code:
+          type: string
+        emission_standard:
+          type: string
+    XInput:
+      description: >-
+        Contains any additional or extended inputs required to confirm an order.
+        This is typically a Form Input. Sometimes, selection of catalog elements
+        is not enough for the BPP to confirm an order. For example, to confirm a
+        flight ticket, the airline requires details of the passengers along with
+        information on baggage, identity, in addition to the class of ticket.
+        Similarly, a logistics company may require details on the nature of
+        shipment in order to confirm the shipping. A recruiting firm may require
+        additional details on the applicant in order to confirm a job
+        application. For all such purposes, the BPP can choose to send this
+        object attached to any object in the catalog that is required to be sent
+        while placing the order. This object can typically be sent at an item
+        level or at the order level. The item level XInput will override the
+        Order level XInput as it indicates a special requirement of information
+        for that particular item. Hence the BAP must render a separate form for
+        the Item and another form at the Order level before confirmation.
+      type: object
+      additionalProperties: false
+      properties:
+        head:
+          description: Provides the header information for the xinput.
+          type: object
+          additionalProperties: false
+          properties:
+            descriptor:
+              $ref: "#/components/schemas/Descriptor"
+            index:
+              type: object
+              additionalProperties: false
+              properties:
+                min:
+                  type: integer
+                cur:
+                  type: integer
+                max:
+                  type: integer
+            headings:
+              type: array
+              items:
+                type: string
+                description: The heading names of the forms
+        form:
+          $ref: "#/components/schemas/Form"
+        form_response:
+          description: Describes the response to a form submission
+          type: object
+          additionalProperties: false
+          properties:
+            status:
+              description: Contains the status of form submission.
+              type: string
+            signature:
+              type: string
+            submission_id:
+              type: string
+            errors:
+              type: array
+              items:
+                $ref: "#/components/schemas/Error"
+        required:
+          description: >-
+            Indicates whether the form data is mandatorily required by the BPP
+            to confirm the order.
+          type: boolean
+x-enum:
+  search:
+    context:
+      action:
+        - code: search
+          description: Buyer app indicates the search intent
+          reference: <PR/Issue/Discussion Links md format text>
+      location: &ref_0
+        country:
+          code:
+            - code: IND
+              description: Represents the country
+              reference: <PR/Issue/Discussion Links md format text>
+        city:
+          code:
+            - code: std:080
+              description: Bangalore
+              reference: <PR/Issue/Discussion Links md format text>
+      domain: &ref_1
+        - code: ONDC:TRV10
+          description: mobility domain Ride
+          reference: <PR/Issue/Discussion Links md format text>
+        - code: ONDC:TRV11
+          description: mobility domain Public Transit
+          reference: <PR/Issue/Discussion Links md format text>
+    message:
+      intent:
+        category:
+          descriptor:
+            code:
+              - code: HOTEL
+                description: Describes the intent category to start search over network.
+                reference: <PR/Issue/Discussion Links md format text
+          time:
+            label:
+              - code: AVAILABLE
+                description: Describes time's label for category
+                reference: <PR/Issue/Discussion Links md format text
+        fulfillment: &ref_3
+          vehicle:
+            category:
+              - code: METRO
+                description: Describes the vehicle category as Metro
+                reference: <PR/Issue/Discussion Links md format text
+              - code: AUTO_RICKSHAW
+                description: Describes the vehicle category as Auto Rickshaw
+                reference: <PR/Issue/Discussion Links md format text
+              - code: CAB
+                description: Describes the vehicle category as cab
+                reference: <PR/Issue/Discussion Links md format text
+              - code: BUS
+                description: Describes the vehicle category as Bus
+                reference: <PR/Issue/Discussion Links md format text
+              - code: AIRLINE
+                description: Describes the vehicle category as Airline
+                reference: <PR/Issue/Discussion Links md format text
+          type:
+            - code: DELIVERY
+              description: Describes the type of fulfillment.
+              reference: <PR/Issue/Discussion Links md format text
+          stops:
+            type:
+              - code: START
+                description: Describes the initial fulfillment location.
+                reference: <PR/Issue/Discussion Links md format text
+              - code: END
+                description: Describes the final fulfillment location.
+                reference: <PR/Issue/Discussion Links md format text
+              - code: INTERMEDIATE_STOP
+                description: Describes the intermediate stops during fulfillment.
+                reference: <PR/Issue/Discussion Links md format text
+              - code: TRANSIT_STOP
+                description: Describes the transit stops during fulfillment.
+                reference: <PR/Issue/Discussion Links md format text
+            authorization:
+              type:
+                - code: OTP
+                  description: >-
+                    Describes OTP as an authorization mechanism used to start or
+                    end the fulfillment of an order.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: QR
+                  description: >-
+                    Describes QR as an authorization mechanism used to start or
+                    end the fulfillment of an order.
+                  reference: <PR/Issue/Discussion Links md format text
+          state: &ref_7
+            descriptor:
+              code:
+                - code: DRIVER_EN_ROUTE_TO_PICKUP
+                  description: The rider is en route
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: RIDE_CANCELLED
+                  description: The rider has canceled the ride.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: PAYMENT_COLLECTED
+                  description: Payment is collected by the rider.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: RIDE_ENDED
+                  description: Describes when the rider concludes the journey.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: DRIVER_AT_PICKUP
+                  description: Describes when the rider is at the pickup location.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: RIDE_STARTED
+                  description: Describes when the rider initiates the journey.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: RIDE_UPDATED
+                  description: Describes the updated state of the ride
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: RIDE_ASSIGNED
+                  description: Describes the state when the ride is assigned.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: RIDE_ENROUTE_PICKUP
+                  description: Rider en route to pickup location."
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: RIDE_ARRIVED_PICKUP
+                  description: >-
+                    Describes the state when the rider has arrived at the pickup
+                    location.
+                  reference: <PR/Issue/Discussion Links md format text
+  on_search:
+    context:
+      action:
+        - code: on_search
+          description: Seller app provides catalog based on search intent.
+          reference: <PR/Issue/Discussion Links md format text>
+      location: *ref_0
+      domain: *ref_1
+    message:
+      catalog:
+        providers:
+          categories:
+            descriptor:
+              code:
+                - code: SEATER
+                  description: Represents type of bus seats available
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: SLEEPER
+                  description: Represents type of bus seats available
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: SEMI_SLEEPER
+                  description: Represents type of bus seats available
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: TICKET
+                  description: Represents type of category
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: PASS
+                  description: Represents type of category
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: ECONOMY
+                  description: Represents type of seat category
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: PREMIUM_ECONOMY
+                  description: Represents type of seat category
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: BUSINESS
+                  description: Represents type of seat category
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: FIRST_CLASS
+                  description: Represents type of seat category
+                  reference: <PR/Issue/Discussion Links md format text
+          time: &ref_2
+            label:
+              - code: ENABLE
+                description: Describes time's label for provider
+                reference: <PR/Issue/Discussion Links md format text
+              - code: AVAILABLE
+                description: Describes time's label for provider
+                reference: <PR/Issue/Discussion Links md format text
+          items: &ref_4
+            time: *ref_2
+            descriptor:
+              code:
+                - code: RIDE
+                  description: Describes the type of ride.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: SJT
+                  description: Describes the kind of ticket Single Journey Ticket
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: SFSJT
+                  description: >-
+                    Describes the kind of ticket special fair Single Journey
+                    Ticket
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: RJT
+                  description: Describes the kind of ticket Return Journey Ticket
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: PASS
+                  description: Describes the kind of ticket Pass (multiple use ticket)
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: SEAT
+                  description: Describes the kind of ticket seat
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: NON_STOP
+                  description: Describes the kind of type of journey
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: CONNECT
+                  description: Describes the kind of type of journey
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: DELUXE
+                  description: Describes type of items for hotel
+                  reference: <PR/Issue/Discussion Links md format text
+          fulfillments: *ref_3
+          payments: &ref_5
+            status:
+              - code: NOT-PAID
+                description: >-
+                  NOT-PAID indicates a payment status where the payment process
+                  has not been completed.
+                reference: <PR/Issue/Discussion Links md format text
+              - code: PAID
+                description: >-
+                  PAID indicates a payment status where the payment process has
+                  been successfully completed.
+                reference: <PR/Issue/Discussion Links md format text
+            collected_by:
+              - code: BPP
+                description: Describes when the seller app is collecting the payment.
+                reference: <PR/Issue/Discussion Links md format text
+              - code: BAP
+                description: Describes when the buyer app is collecting the payment.
+                reference: <PR/Issue/Discussion Links md format text
+            type:
+              - code: PRE-ORDER
+                description: Payment occurs prior to order placement.
+                reference: <PR/Issue/Discussion Links md format text
+              - code: ON-FULFILLMENT
+                description: Payment occurs upon completion of the journey.
+                reference: <PR/Issue/Discussion Links md format text
+              - code: POST-FULFILLMENT
+                description: Payment occurs after the completion of the journey.
+                reference: <PR/Issue/Discussion Links md format text
+              - code: PART-PAYMENT
+                description: Describe the type of payment.
+                reference: <PR/Issue/Discussion Links md format text
+          locations:
+            descriptor:
+              code:
+                - code: HOTEL:5
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: APARTMENT:2
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: RESORT:3
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: HOSTEL:5
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: HOUSEBOAT:1
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: ENTIRE_APARTMENT:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: FARM_STAY:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: CHALETS:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: TENT:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: VILLA:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: HOMESTAY:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: GUEST_HOUSE:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: TREE_HOUSE:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: CAMPSITE:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: LODGE:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: MOTELS:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: SERVICED_APARTMENT:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: BED_BREAKFAST:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: INN:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+                - code: OTHER:4
+                  description: Describes the property type with star rating.
+                  reference: <PR/Issue/Discussion Links md format text
+  select:
+    context:
+      action:
+        - code: select
+          description: Buyer app communicates selected items and quantities.
+          reference: <PR/Issue/Discussion Links md format text>
+      location: *ref_0
+      domain: *ref_1
+    message: &ref_6
+      order:
+        items: *ref_4
+        fulfillments: *ref_3
+        payments: *ref_5
+        status:
+          - code: SOFT-CANCEL
+            description: >-
+              Describes a soft-cancel request initiated by the buyer app, a step
+              preceding cancellation.
+            reference: <PR/Issue/Discussion Links md format text
+          - code: CONFIRM-CANCEL
+            description: >-
+              Describes a confirm-cancel request initiated by the buyer app,
+              confirming the order cancellation
+            reference: <PR/Issue/Discussion Links md format text
+          - code: SOFT-UPDATE
+            description: >-
+              Describes a soft-update request initiated by the buyer app,
+              occurring before the actual order update.
+            reference: <PR/Issue/Discussion Links md format text
+          - code: CONFIRM-UPDATE
+            description: >-
+              Describes a confirm-update request initiated by the buyer app,
+              confirming the order update.
+            reference: <PR/Issue/Discussion Links md format text
+          - code: ACTIVE
+            description: Describes the status of the order.
+            reference: <PR/Issue/Discussion Links md format text
+          - code: COMPLETE
+            description: Describes the status of the order.
+            reference: <PR/Issue/Discussion Links md format text
+          - code: CANCELLED
+            description: Describes the status of the order.
+            reference: <PR/Issue/Discussion Links md format text
+  on_select:
+    context:
+      action:
+        - code: on_select
+          description: >-
+            Seller app provides serviceability info, quotes, and O2D TAT for
+            selected items.
+          reference: <PR/Issue/Discussion Links md format text>
+      location: *ref_0
+      domain: *ref_1
+    message: *ref_6
+  init:
+    context:
+      action:
+        - code: init
+          description: >-
+            Buyer and seller apps confirm terms & conditions before placing
+            orders.
+          reference: <PR/Issue/Discussion Links md format text>
+      location: *ref_0
+      domain: *ref_1
+    message: *ref_6
+  on_init:
+    context:
+      action:
+        - code: on_init
+          description: >-
+            Buyer and seller apps agree to terms & conditions before placing
+            orders.
+          reference: <PR/Issue/Discussion Links md format text>
+      location: *ref_0
+      domain: *ref_1
+    message:
+      order:
+        items: *ref_4
+        fulfillments: *ref_3
+        payments: *ref_5
+        cancellation_terms:
+          fulfillment_state: *ref_7
+  confirm:
+    context:
+      action:
+        - code: confirm
+          description: Buyer app submits orders on behalf of the buyer.
+          reference: <PR/Issue/Discussion Links md format text>
+      location: *ref_0
+      domain: *ref_1
+    message: *ref_6
+  on_confirm:
+    context:
+      action:
+        - code: on_confirm
+          description: >-
+            Seller app responds to the order with auto-acceptance, deferred
+            acceptance, or rejection.
+          reference: <PR/Issue/Discussion Links md format text>
+      location: *ref_0
+      domain: *ref_1
+    message: *ref_6
+  status:
+    context:
+      action:
+        - code: status
+          description: Buyer app request for status of the order
+          reference: <PR/Issue/Discussion Links md format text>
+      location: *ref_0
+      domain: *ref_1
+  on_status:
+    context:
+      action:
+        - code: on_status
+          description: Seller app return order with status , Driver pickup - driver drop
+          reference: <PR/Issue/Discussion Links md format text>
+      location: *ref_0
+      domain: *ref_1
+    message: *ref_6
+  cancel:
+    context:
+      action:
+        - code: cancel
+          description: Buyer app requests order cancellation."
+          reference: <PR/Issue/Discussion Links md format text>
+      location: *ref_0
+      domain: *ref_1
+  on_cancel:
+    context:
+      action:
+        - code: on_cancel
+          description: Seller app specifies the cancellation status.
+          reference: <PR/Issue/Discussion Links md format text>
+      location: *ref_0
+      domain: *ref_1
+    message: *ref_6
+  update:
+    context:
+      action:
+        - code: update
+          description: Buyer app requests order update."
+          reference: <PR/Issue/Discussion Links md format text>
+      location: *ref_0
+      domain: *ref_1
+    message: *ref_6
+  on_update:
+    context:
+      action:
+        - code: on_cancel
+          description: Seller app specifies the update status.
+          reference: <PR/Issue/Discussion Links md format text>
+      location: *ref_0
+      domain: *ref_1
+    message: *ref_6
+x-tags:
+  search:
+    message:
+      intent:
+        payment: &ref_10
+          tags:
+            - &ref_9
+              code: BUYER_FINDER_FEES
+              description: Describes the finder fees for buyer
+              reference: <PR/Issue/Discussion Links md format text>
+              list:
+                - code: BUYER_FINDER_FEES_TYPE
+                  description: Buyer finder fee type
+                  reference: <PR/Issue/Discussion Links md format text>
+                - code: BUYER_FINDER_FEES_PERCENTAGE
+                  description: Buyer finder fee in percentage
+                  reference: <PR/Issue/Discussion Links md format text>
+                - code: BUYER_FINDER_FEES_AMOUNT
+                  description: Buyer finder fee in amount
+                  reference: <PR/Issue/Discussion Links md format text>
+            - code: SETTLEMENT_TERMS
+              description: Describes the settlement terms
+              reference: <PR/Issue/Discussion Links md format text>
+              list:
+                - code: SETTLEMENT_WINDOW
+                  description: Time window to complete settlement
+                  reference: <PR/Issue/Discussion Links md format text>
+                - code: SETTLEMENT_BASIS
+                  description: Basis required to complete settlement
+                  reference: <PR/Issue/Discussion Links md format text>
+                - code: SETTLEMENT_TYPE
+                  description: Payment method to complete settlement
+                  reference: <PR/Issue/Discussion Links md format text>
+                - code: MANDATORY_ARBITRATION
+                  description: >-
+                    Flag to denote if dispute can be resolved through
+                    arbitration
+                  reference: <PR/Issue/Discussion Links md format text>
+                - code: COURT_JURISDICTION
+                  description: Denotes court that will have jurisdiction for the case
+                  reference: <PR/Issue/Discussion Links md format text>
+                - code: DELAY_INTEREST
+                  description: Denotes interest to be paid as a delay charge
+                  reference: <PR/Issue/Discussion Links md format text>
+                - code: STATIC_TERMS
+                  description: Terms for settlement
+                  reference: <PR/Issue/Discussion Links md format text>
+                - code: SETTLEMENT_AMOUNT
+                  description: Denotes settlement amount
+                  reference: <PR/Issue/Discussion Links md format text>
+            - code: LINKED-PAYMENTS
+              description: Describes the linked payments
+              reference: <PR/Issue/Discussion Links md format text>
+              list:
+                - code: pymnt-4
+                  description: Describes the info about adults
+                  reference: <PR/Issue/Discussion Links md format text>
+            - code: ADV-DEPOSIT
+              description: Describes advance deposits for a payment
+              reference: <PR/Issue/Discussion Links md format text>
+              list: &ref_8
+                - code: AMOUNT
+                  description: Describes amount for deposit
+                  reference: <PR/Issue/Discussion Links md format text>
+            - code: FINAL-PAYMENT
+              description: Describes the final payment
+              reference: <PR/Issue/Discussion Links md format text>
+              list: *ref_8
+        tags:
+          - code: BAP_TERMS
+            description: Describes the BAP terms
+            reference: <PR/Issue/Discussion Links md format text>
+            list:
+              - code: STATIC_TERMS
+                description: Describes the static terms
+                reference: <PR/Issue/Discussion Links md format text>
+              - code: STATIC_TERMS_NEW
+                description: Describes the static terms
+                reference: <PR/Issue/Discussion Links md format text>
+              - code: EFFECTIVE_DATE
+                description: Describes the effective date
+                reference: <PR/Issue/Discussion Links md format text>
+          - *ref_9
+  on_search:
+    message:
+      catalog:
+        providers:
+          items: &ref_12
+            tags:
+              - code: FARE_POLICY
+                description: Details about fare for the ride
+                reference: <PR/Issue/Discussion Links md format text>
+                list:
+                  - code: MIN_FARE
+                    description: Describes the minimum fare
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: MIN_FARE_DISTANCE_KM
+                    description: Describes the minimum fare per KM
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: PER_KM_CHARGE
+                    description: Describes the per km charge
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: PICKUP_CHARGE
+                    description: Describes the pickup charge
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: WAITING_CHARGE_PER_MIN
+                    description: Describes the waiting charge per minute
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: NIGHT_CHARGE_MULTIPLIER
+                    description: Describes the times need to multiply for night charge
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: NIGHT_SHIFT_START_TIME
+                    description: Describes the time when night shift starts
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: NIGHT_SHIFT_END_TIME
+                    description: Describes the time when night shift ends
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: RESTRICTED_PERSON
+                    description: Describes the restricted person
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: RESTRICTION_PROOF
+                    description: Describes the proof needed for restriction
+                    reference: <PR/Issue/Discussion Links md format text>
+              - code: GENERAL_INFO
+                description: General information about airlines
+                reference: <PR/Issue/Discussion Links md format text>
+                list:
+                  - code: CABIN_BAGGAGE
+                    description: Allowed limit for cabin baggage
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: CHECK_IN_BAGGAGE
+                    description: Allowed limit for checkin baggage
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: PROHIBITED_ITEMS
+                    description: Describes the list of prohibited items
+                    reference: <PR/Issue/Discussion Links md format text>
+          fulfillments: &ref_11
+            tags:
+              - code: SEAT_GRID
+                description: Seat details to identify specifics of seat
+                reference: <PR/Issue/Discussion Links md format text>
+                list:
+                  - code: X
+                    description: Describes the x-axis co-ordinate of seat
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: "Y"
+                    description: Describes the y-axis co-ordinate of seat
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: Z
+                    description: Describes the z-axis co-ordinate of seat
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: X_SIZE
+                    description: describes the x-axis size of seat
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: Y_SIZE
+                    description: Describes the y-axis size of seat
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: SEAT_NUMBER
+                    description: Describes the seat number for assigned ticket
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: RESTRICTED_GENDER
+                    description: Describes the restricted gender for assigned ticket
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: SINGLE_SEAT
+                    description: describes if assigned ticket seat is single or not
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: SEAT_PRICE
+                    description: Describes the price for particular seat
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: ITEM_ID
+                    description: Describes the item id to which the seat grid is attached
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: SELECTED
+                    description: Describes the seat status selected by the buyer app
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: AVAILABLE
+                    description: Describes whether seat is available for selection or not
+                    reference: <PR/Issue/Discussion Links md format text>
+              - code: VEHICLE_GRID
+                description: Vehicle details to identify specifics of vehicle
+                reference: <PR/Issue/Discussion Links md format text>
+                list:
+                  - code: X_MAX
+                    description: Describes the max x-axis co-ordinate of vehicle
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: Y_MAX
+                    description: Describes the max y-axis co-ordinate of vehicle
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: Z_MAX
+                    description: Describes the max z-axis co-ordinate of vehicle
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: X_LOBBY_START
+                    description: Describes the x-axis starting point
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: X_LOBBY_SIZE
+                    description: Describes the x-axis size of lobby
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: Y_LOBBY_START
+                    description: Describes the y-axis starting point
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: Y_LOBBY_SIZE
+                    description: Describes the y-axis size of lobby
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: SEAT_SELECTION
+                    description: Describes whether seat selection is mandatory or optional
+                    reference: <PR/Issue/Discussion Links md format text>
+              - code: VEHICLE_AVAIBALITY
+                description: Details about the availability of a vehicle
+                reference: <PR/Issue/Discussion Links md format text>
+                list:
+                  - code: AVALIABLE_SEATS
+                    description: Describes the available seats present in vehicle
+                    reference: <PR/Issue/Discussion Links md format text>
+              - code: ROUTE_INFO
+                description: Describes the information about the route
+                reference: <PR/Issue/Discussion Links md format text>
+                list:
+                  - code: ROUTE_ID
+                    description: Describes the route id of the journey for bus
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: ROUTE_DIRECTION
+                    description: Describes the direction of a particular route
+                    reference: <PR/Issue/Discussion Links md format text>
+              - code: GUESTS
+                description: Describes the information about the guests
+                reference: <PR/Issue/Discussion Links md format text>
+                list:
+                  - code: ADULTS
+                    description: Describes the info about adults
+                    reference: <PR/Issue/Discussion Links md format text>
+                  - code: CHILDREN
+                    description: Describes the info about children
+                    reference: <PR/Issue/Discussion Links md format text>
+          payments: *ref_10
+  select:
+    message:
+      order:
+        fulfillments: *ref_11
+  on_select: &ref_14
+    message:
+      order:
+        fulfillments: *ref_11
+        items: *ref_12
+        provider: &ref_13
+          tags:
+            - code: FARE_TYPE
+              description: Details about type of fare for the ride
+              reference: <PR/Issue/Discussion Links md format text>
+              list:
+                - code: REGULAR
+                  description: Describes the regular type fare
+                  reference: <PR/Issue/Discussion Links md format text>
+                - code: STUDENT
+                  description: Describes the special type of fare for students
+                  reference: <PR/Issue/Discussion Links md format text>
+                - code: SENIOR_CITIZEN
+                  description: Describes the special type of fare for senior citizens
+                  reference: <PR/Issue/Discussion Links md format text>
+                - code: ARMED_FORCES
+                  description: Describes the special type of fare for armed personnel
+                  reference: <PR/Issue/Discussion Links md format text>
+                - code: DOCTORS_NURSES
+                  description: >-
+                    Describes the special type of fare for armed doctors &
+                    nurses
+                  reference: <PR/Issue/Discussion Links md format text>
+  init:
+    message:
+      order:
+        payments: *ref_10
+  on_init:
+    message:
+      order:
+        fulfillments: *ref_11
+        items: *ref_12
+        provider: *ref_13
+        payments: *ref_10
+  on_confirm: *ref_14
+  on_status:
+    message:
+      order:
+        fulfillments: *ref_11
+        items: *ref_12
+  on_cancel: *ref_14
+  on_update: *ref_14
+x-flows:
+  - summary: Hotel Booking - Flow
+    details:
+      - description: >-
+          The illustrative flow to perform a transaction of the nature where in
+          a buyer would like to book a service.
+        mermaid: |-
+          sequenceDiagram
+            title Hotel Discovery
+            Buyer Platform (BAP)->>Gateway (BG): search
+            Gateway (BG) ->> Buyer Platform (BAP): ACK
+            Gateway (BG)->>Registry: Lookup Seller Platforms (lookup)
+            Registry->>Gateway (BG): List of Seller Platforms (200 OK)
+            Gateway (BG)->>Seller Platform (BPP): search
+            Seller Platform (BPP)->>Gateway (BG) : ACK
+            Seller Platform (BPP)->>Buyer Platform (BAP): Publish Catalog of Seller 1 (on_search)
+            Buyer Platform (BAP)->>Seller Platform (BPP): ACK
+      - description: Ordering
+        mermaid: |-
+          sequenceDiagram
+            title Selection
+            participant Buyer Platform (BAP)
+            participant Seller Platform (BPP)
+            Buyer Platform (BAP)->>Seller Platform (BPP): select
+            Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+            Seller Platform (BPP)->>Buyer Platform (BAP):on_select
+            Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+      - description: Initializing the order
+        mermaid: |-
+          sequenceDiagram
+            title Initializing Order
+            participant Buyer Platform (BAP)
+            participant Seller Platform (BPP)
+            Buyer Platform (BAP)->>Seller Platform (BPP): init
+            Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+            Seller Platform (BPP)->>Buyer Platform (BAP):on_init
+            Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+      - description: Order Confirmation
+        mermaid: |-
+          sequenceDiagram
+            title  Order Confirmation
+            participant Buyer Platform (BAP)
+            participant Seller Platform (BPP)
+            Buyer Platform (BAP)->>Seller Platform (BPP): confirm
+            Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+            Seller Platform (BPP)->>Buyer Platform (BAP):on_confirm
+            Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+      - description: Fulfillment
+        mermaid: |-
+          sequenceDiagram
+            title Order Fulfillment
+            participant Buyer Platform (BAP)
+            participant Seller Platform (BPP)
+            Buyer Platform (BAP)->>Seller Platform (BPP): status-Request application status
+            Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+            Seller Platform (BPP)->>Buyer Platform (BAP):on_status - Provide application status
+            Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+    steps:
+      - summary: Search for the hotels (city-based)
+        api: search
+        details: &ref_15
+          - description: User searches over the network to avail the services
+            mermaid: |-
+              sequenceDiagram
+                rect rgb(191, 223, 255)
+                Buyer Platform (BAP)->>Gateway (BG): search
+                Gateway (BG) ->> Buyer Platform (BAP): ACK
+                Gateway (BG)->>Registry: Lookup Seller Platforms (lookup)
+                Registry->>Gateway (BG): List of Seller Platforms (200 OK)
+                Gateway (BG)->>Seller Platform (BPP): search
+                Seller Platform (BPP)->>Gateway (BG) : ACK
+                end
+                Seller Platform (BPP)->>Buyer Platform (BAP): Publish Catalog of Seller 1 (on_search)
+                Buyer Platform (BAP)->>Seller Platform (BPP): ACK
+        reference: if any
+        example:
+          summary: search by city
+          description: search by city
+          value: &ref_18
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: a9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: bb579fb8-cb82-4824-be12-fcbc405b6608
+              action: search
+              timestamp: "2023-12-20T05:23:03.443Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              ttl: PT30S
+            message:
+              intent:
+                category:
+                  descriptor:
+                    code: HOTEL
+                tags:
+                  - descriptor:
+                      code: BAP_TERMS
+                    list:
+                      - descriptor:
+                          code: STATIC_TERMS
+                        value: ""
+                      - descriptor:
+                          code: STATIC_TERMS_NEW
+                        value: >-
+                          https://github.com/ONDC-Official/static-terms//buyerNP_BNP/1.0/tc.pdf
+                      - descriptor:
+                          code: EFFECTIVE_DATE
+                        value: "2024-01-01T00:00:00.000Z"
+                  - descriptor:
+                      code: BUYER_FINDER_FEES
+                    list:
+                      - descriptor:
+                          code: BUYER_FINDER_FEES_PERCENTAGE
+                        value: "3"
+      - summary: Get a list of all the accommodations in that particular city
+        api: on_search
+        details: &ref_16
+          - description: >-
+              Provider sends the catalog of all services that can be used for
+              hotel booking.
+            mermaid: |-
+              sequenceDiagram
+                Buyer Platform (BAP)->>Gateway (BG): search
+                Gateway (BG) ->> Buyer Platform (BAP): ACK
+                Gateway (BG)->>Registry: Lookup Seller Platforms (lookup)
+                Registry->>Gateway (BG): List of Seller Platforms (200 OK)
+                Gateway (BG)->>Seller Platform (BPP): search
+                Seller Platform (BPP)->>Gateway (BG) : ACK
+                rect rgb(191, 223, 255)
+                Seller Platform (BPP)->>Buyer Platform (BAP): Publish Catalog of Seller 1 (on_search)
+                Buyer Platform (BAP)->>Seller Platform (BPP): ACK
+                end
+        reference: if any
+        example: &ref_17
+          value: &ref_19
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: a9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: bb579fb8-cb82-4824-be12-fcbc405b6608
+              action: on_search
+              timestamp: "2023-12-20T05:28:04.300Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              catalog:
+                descriptor:
+                  name: ONDC Hotel Groups
+                  code: BPP Code
+                  short_desc: Hotel BPP ONDC
+                  long_desc: "ONDC Hotel Groups is a Hotel Aggregator "
+                  images:
+                    - url: https://remote-image.ondc.hotelbpp.com
+                providers:
+                  - id: P1
+                    time:
+                      label: ENABLE
+                      timestamp: "2023-12-20T05:28:04.300Z"
+                    descriptor:
+                      name: ONDC Hotel Provider ABC
+                      code: Hotel
+                      short_desc: Hotel ABC ONDC is a renowned hotel provider in India
+                      long_desc: >-
+                        Hotel ABC ONDC Provider is equipped with a variety of
+                        on-site amenities to enhance the overall quality and
+                        enjoyment of your experience
+                      images:
+                        - url: https://remote-image-ABC.ondc.hotelbpp.com
+                        - url: https://remote-image-ABC-2.ondc.hotelbpp.com
+                    locations:
+                      - id: L1
+                        gps: 12.88984957221858, 78.00666372461477
+                        address: M.Hosahalli
+                        city:
+                          name: Bangalore
+                        state:
+                          name: Karnataka
+                        area_code: "563139"
+                        rating: "5"
+                    categories:
+                      - id: dlx-1234
+                        descriptor:
+                          name: Deluxe Room
+                      - id: fml-ste
+                        descriptor:
+                          name: Family Suite
+                    payments:
+                      - id: pymnt-1
+                        type: PRE-ORDER
+                      - id: pymnt-2
+                        type: ON-FULFILLMENT
+                      - id: pymnt-3
+                        type: PART-PAYMENT
+                    items:
+                      - id: Accommodation-1
+                        time:
+                          label: ENABLE
+                          timestamp: "2023-12-20T05:28:04.300Z"
+                        descriptor:
+                          name: Deluxe Room
+                          code: DELUXE
+                          additional_desc:
+                            url: >-
+                              https://remote-image-Acc-1-details.ondc.hotelbpp.com
+                            content_type: application/json
+                          images:
+                            - url: https://remote-image-Acc-1-1.ondc.hotelbpp.com
+                            - url: https://remote-image-Acc-1-2.ondc.hotelbpp.com
+                        price:
+                          currency: INR
+                          value: "2000.00"
+                          maximum_value: "3000.00"
+                        quantity:
+                          available:
+                            count: 12
+                          maximum:
+                            count: 4
+                        location_ids:
+                          - L1
+                        category_ids:
+                          - dlx-1234
+                        payment_ids:
+                          - pymnt-1
+                          - pymnt-2
+                          - pymnt-3
+                        add_ons:
+                          - id: B&B
+                            descriptor:
+                              name: Breakfast Included
+                              short_desc: Accommodation with breakfast included
+                            price:
+                              currency: INR
+                              value: "200.00"
+                              maximum_value: "300.00"
+                          - id: full-board
+                            descriptor:
+                              name: Full Board
+                              short_desc: >-
+                                Accommodation with all meals included
+                                (breakfast, lunch, and dinner)
+                            price:
+                              currency: INR
+                              value: "500.00"
+                              maximum_value: "700.00"
+                          - id: extra-bed-child
+                            descriptor:
+                              name: child bed
+                              short_desc: Accomodation with extra child bed
+                            price:
+                              currency: INR
+                              value: "200.00"
+                              maximum_value: "300.00"
+                          - id: extra-bed-adult
+                            descriptor:
+                              name: adult bed
+                              short_desc: Accomodation with extra adult bed
+                            price:
+                              currency: INR
+                              value: "300.00"
+                              maximum_value: "500.00"
+                        cancellation_terms:
+                          - external_ref:
+                              mimetype: application/json
+                              url: https://remote-terms-ABC.ondc.hotelbpp.com
+                        recommended: true
+                      - id: Accommodation-2
+                        time:
+                          label: ENABLE
+                          timestamp: "2023-12-20T05:28:04.300Z"
+                          duration: PT2H
+                          range:
+                            start: "2023-12-20T05:28:04.300Z"
+                            end: "2023-12-20T06:28:04.300Z"
+                        descriptor:
+                          name: Family Suite
+                          code: SUITE
+                          additional_desc:
+                            url: >-
+                              https://remote-image-Acc-2-details.ondc.hotelbpp.com
+                            content_type: application/json
+                          images:
+                            - url: https://remote-image-Acc-2-1.ondc.hotelbpp.com
+                            - url: https://remote-image-Acc-2-2.ondc.hotelbpp.com
+                        price:
+                          currency: INR
+                          value: "7000.00"
+                          maximum_value: "8000.00"
+                        quantity:
+                          available:
+                            count: 2
+                          maximum:
+                            count: 1
+                        location_ids:
+                          - L1
+                        category_ids:
+                          - fml-ste
+                        payment_ids:
+                          - pymnt-1
+                        add_ons:
+                          - id: full-board
+                            descriptor:
+                              name: Full Board
+                              short_desc: >-
+                                Accommodation with all meals included
+                                (breakfast, lunch, and dinner)
+                            price:
+                              currency: INR
+                              value: "3000.00"
+                              maximum_value: "4000.00"
+                        cancellation_terms:
+                          - external_ref:
+                              mimetype: application/json
+                              url: https://remote-terms-ABC.ondc.hotelbpp.com
+                        recommended: true
+      - summary: Search - Incremental catalog refresh
+        api: search
+        details: *ref_15
+        reference: if any
+        example:
+          summary: incremental search
+          description: incremental search
+          value: &ref_25
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: e0caecca-10b7-4d19-b640-b047a7c62196
+              message_id: bb579fb8-cb82-4824-be12-fcbc405b6608
+              action: search
+              timestamp: "2023-12-20T05:23:03.443Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              ttl: PT30S
+            message:
+              intent:
+                category:
+                  descriptor:
+                    code: HOTEL
+                tags:
+                  - descriptor:
+                      code: BAP_TERMS
+                    list:
+                      - descriptor:
+                          code: STATIC_TERMS
+                        value: ""
+                      - descriptor:
+                          code: STATIC_TERMS_NEW
+                        value: >-
+                          https://github.com/ONDC-Official/static-terms//buyerNP_BNP/1.0/tc.pdf
+                      - descriptor:
+                          code: EFFECTIVE_DATE
+                        value: "2024-01-01T00:00:00.000Z"
+                  - descriptor:
+                      code: BUYER_FINDER_FEES
+                    list:
+                      - descriptor:
+                          code: BUYER_FINDER_FEES_PERCENTAGE
+                        value: "3"
+                  - descriptor:
+                      code: CATALOG_INC
+                    list:
+                      - descriptor:
+                          code: MODE
+                        value: START
+      - summary: Get a list of all the accommodations with delta changes
+        api: on_search
+        details: *ref_16
+        reference: if any
+        example:
+          value: &ref_33
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: a9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: bb579fb8-cb82-4824-be12-fcbc405b6608
+              action: on_search
+              timestamp: "2023-12-20T05:28:04.300Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              catalog:
+                providers:
+                  - id: P1
+                    categories:
+                      - id: dlx-1234
+                        descriptor:
+                          name: Deluxe Room
+                    items:
+                      - id: Accommodation-1
+                        time:
+                          label: ENABLE
+                          timestamp: "2023-12-20T05:28:04.300Z"
+                        descriptor:
+                          name: Deluxe Room
+                          code: DELUXE
+                          additional_desc:
+                            url: >-
+                              https://remote-image-Acc-1-details.ondc.hotelbpp.com
+                            content_type: application/json
+                          images:
+                            - url: https://remote-image-Acc-1-1.ondc.hotelbpp.com
+                            - url: https://remote-image-Acc-1-2.ondc.hotelbpp.com
+                        price:
+                          currency: INR
+                          value: "1500.00"
+                          maximum_value: "3000.00"
+                        quantity:
+                          available:
+                            count: 11
+                          maximum:
+                            count: 4
+                        location_ids:
+                          - L1
+                        category_ids:
+                          - dlx-1234
+                        payment_ids:
+                          - pymnt-1
+                          - pymnt-2
+                          - pymnt-3
+                        add_ons:
+                          - id: B&B
+                            descriptor:
+                              name: Breakfast Included
+                              short_desc: Accommodation with breakfast included
+                            price:
+                              currency: INR
+                              value: "200.00"
+                              maximum_value: "300.00"
+                          - id: full-board
+                            descriptor:
+                              name: Full Board
+                              short_desc: >-
+                                Accommodation with all meals included
+                                (breakfast, lunch, and dinner)
+                            price:
+                              currency: INR
+                              value: "500.00"
+                              maximum_value: "700.00"
+                          - id: extra-bed-child
+                            descriptor:
+                              name: child bed
+                              short_desc: Accomodation with extra child bed
+                            price:
+                              currency: INR
+                              value: "200.00"
+                              maximum_value: "300.00"
+                          - id: extra-bed-adult
+                            descriptor:
+                              name: adult bed
+                              short_desc: Accomodation with extra adult bed
+                            price:
+                              currency: INR
+                              value: "300.00"
+                              maximum_value: "500.00"
+                        cancellation_terms:
+                          - external_ref:
+                              mimetype: application/json
+                              url: https://remote-terms-ABC.ondc.hotelbpp.com
+                        recommended: true
+      - summary: Search for the availability of hotel (with time range)
+        api: search
+        details: *ref_15
+        reference: if any
+        example:
+          summary: search for the availability(with time range)
+          description: Search for the availability of accommodation (with time range)
+          value: &ref_23
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: a9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: bb579fb8-cb82-4824-be12-fcbc405b6608
+              action: search
+              timestamp: "2023-12-20T05:23:03.443Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              ttl: PT30S
+            message:
+              intent:
+                category:
+                  descriptor:
+                    code: HOTEL
+                  time:
+                    label: AVAILABLE
+                    range:
+                      start: "2023-12-25T00:00:00.000Z"
+                      end: "2023-12-27T00:00:00.000Z"
+                fulfillment:
+                  stops:
+                    - type: END
+                      location:
+                        gps: 12.82735998361846, 77.69157068978166
+                        area_code: "560100"
+                tags:
+                  - descriptor:
+                      code: BAP_TERMS
+                    list:
+                      - descriptor:
+                          code: STATIC_TERMS
+                        value: ""
+                      - descriptor:
+                          code: STATIC_TERMS_NEW
+                        value: >-
+                          https://github.com/ONDC-Official/static-terms//buyerNP_BNP/1.0/tc.pdf
+                      - descriptor:
+                          code: EFFECTIVE_DATE
+                        value: "2024-01-01T00:00:00.000Z"
+                  - descriptor:
+                      code: BUYER_FINDER_FEES
+                    list:
+                      - descriptor:
+                          code: BUYER_FINDER_FEES_PERCENTAGE
+                        value: "3"
+      - summary: Get a list of all the available accommodations
+        api: on_search
+        details: *ref_16
+        reference: if any
+        example: *ref_17
+      - summary: Search for a provider specific hotel (Optional)
+        api: search
+        details: *ref_15
+        reference: if any
+        example:
+          summary: search by provider
+          description: search by provider (id or name)
+          value: &ref_24
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: a9aaecca-10b7-4d19-b640-b047a7c62176
+              message_id: bb579fb8-cb82-4824-be12-fbcb306d2745
+              action: search
+              timestamp: "2023-12-20T07:23:03.443Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              intent:
+                category:
+                  descriptor:
+                    code: HOTEL
+                provider:
+                  id: ondc-hotel-provider1
+                  descriptor:
+                    name: hotel-abc
+                  time:
+                    label: AVAILABLE
+                    range:
+                      start: "2023-12-25T00:00:00.000Z"
+                      end: "2023-12-27T00:00:00.000Z"
+                fulfillment:
+                  stops:
+                    - type: END
+                      location:
+                        gps: 12.82735998361846, 77.69157068978166
+                        area_code: "560100"
+                tags:
+                  - descriptor:
+                      code: BAP_TERMS
+                    list:
+                      - descriptor:
+                          code: STATIC_TERMS
+                        value: ""
+                      - descriptor:
+                          code: STATIC_TERMS_NEW
+                        value: >-
+                          https://github.com/ONDC-Official/static-terms//buyerNP_BNP/1.0/tc.pdf
+                      - descriptor:
+                          code: EFFECTIVE_DATE
+                        value: "2024-01-01T00:00:00.000Z"
+                  - descriptor:
+                      code: BUYER_FINDER_FEES
+                    list:
+                      - descriptor:
+                          code: BUYER_FINDER_FEES_PERCENTAGE
+                        value: "3"
+      - summary: Get a list of all the accommodations from that particular provider
+        api: on_search
+        details: *ref_16
+        reference: if any
+        example: *ref_17
+      - summary: Selection of specific service
+        api: select
+        details:
+          - description: >-
+              The end consumer have to select the specific service and would
+              like to have the necesary details
+            mermaid: |-
+              sequenceDiagram
+                participant Buyer Platform (BAP)
+                participant Seller Platform (BPP)
+                rect rgb(191, 223, 255)
+                Buyer Platform (BAP)->>Seller Platform (BPP): select
+                Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+                end
+                Seller Platform (BPP)->>Buyer Platform (BAP):on_select
+                Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+        reference: if any
+        example:
+          value: &ref_27
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: b9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: aa579fb8-cb82-4824-be12-fcbc405b6608
+              action: select
+              timestamp: "2023-12-20T05:28:04.400Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              order:
+                provider:
+                  id: P1
+                  time:
+                    label: AVAILABLE
+                    range:
+                      start: "2023-12-25T00:00:00.000Z"
+                      end: "2023-12-27T00:00:00.000Z"
+                items:
+                  - id: Accommodation-1
+                    location_ids:
+                      - L1
+                    quantity:
+                      selected:
+                        count: 1
+                    add_ons:
+                      - id: full-board
+                fulfillments:
+                  - tags:
+                      - descriptor:
+                          code: GUESTS
+                        list:
+                          - descriptor:
+                              code: ADULTS
+                            value: "1"
+                          - descriptor:
+                              code: CHILDREN
+                            value: "0"
+      - summary: Provider platform provides the quote for selected service of hotel
+        api: on_select
+        details:
+          - description: >-
+              Provider platform responds with the service detailed information
+              and quotes for the specific service that consumer would like to
+              avail
+            mermaid: |-
+              sequenceDiagram
+                participant Buyer Platform (BAP)
+                participant Seller Platform (BPP)
+                Buyer Platform (BAP)->>Seller Platform (BPP): select
+                Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+                rect rgb(191, 223, 255)
+                Seller Platform (BPP)->>Buyer Platform (BAP):on_select
+                Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+                end
+        reference: if any
+        example:
+          value: &ref_34
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: b9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: aa579fb8-cb82-4824-be12-fcbc405b6608
+              action: on_select
+              timestamp: "2023-12-20T05:28:04.401Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              order:
+                provider:
+                  id: P1
+                items:
+                  - id: Accommodation-1
+                    add_ons:
+                      - id: full-board
+                    payment_ids:
+                      - pymnt-3
+                quote:
+                  price:
+                    currency: INR
+                    value: "3025.00"
+                  breakup:
+                    - item:
+                        id: Accommodation-1
+                        quantity:
+                          selected:
+                            count: 1
+                        price:
+                          currency: INR
+                          value: "2000.00"
+                        add_ons:
+                          - id: full-board
+                            price:
+                              currency: INR
+                              value: "500.00"
+                      title: >-
+                        Deluxe Room accommodation with all meals included
+                        (breakfast, lunch, and dinner)
+                      price:
+                        currency: INR
+                        value: "2500.00"
+                    - title: Service Tax @ 9%
+                      price:
+                        currency: INR
+                        value: "225"
+                    - title: GST @ 12%
+                      price:
+                        currency: INR
+                        value: "300"
+                  ttl: P1D
+                payments:
+                  - id: pymnt-1
+                    type: PRE-ORDER
+                    tags:
+                      - descriptor:
+                          code: FULL-PAYMENT
+                  - id: pymnt-2
+                    type: ON-FULFILLMENT
+                    tags:
+                      - descriptor:
+                          code: FULL-PAYMENT
+                  - id: pymnt-3
+                    type: PART-PAYMENT
+                    tags:
+                      - descriptor:
+                          code: LINKED-PAYMENTS
+                        list:
+                          - descriptor:
+                              code: pymnt-4
+                            value: "1"
+                          - descriptor:
+                              code: pymnt-5
+                            value: "2"
+                  - id: pymnt-4
+                    type: PRE-ORDER
+                    tags:
+                      - descriptor:
+                          code: ADV-DEPOSIT
+                    params:
+                      currency: INR
+                      amount: "2000.00"
+                  - id: pymnt-5
+                    type: ON-FULFILLMENT
+                    tags:
+                      - descriptor:
+                          code: FINAL-PAYMENT
+                    params:
+                      amount: "1025.00"
+                      currency: INR
+            error:
+              code: ""
+              message: ""
+      - summary: Consumer platform initializes the order
+        api: init
+        details:
+          - description: >-
+              Consumer platform shares the terms of order and initializes the
+              order
+            mermaid: |-
+              sequenceDiagram
+                participant Buyer Platform (BAP)
+                participant Seller Platform (BPP)
+                rect rgb(191, 223, 255)
+                Buyer Platform (BAP)->>Seller Platform (BPP): init
+                Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+                end
+                Seller Platform (BPP)->>Buyer Platform (BAP):on_init
+                Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+        reference: if any
+        example:
+          value: &ref_29
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: b9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: ab379fb8-cb82-4824-be12-fcbc405b6608
+              action: init
+              timestamp: "2023-12-20T05:28:04.405Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              order:
+                provider:
+                  id: P1
+                items:
+                  - id: Accommodation-1
+                    location_ids:
+                      - L1
+                    quantity:
+                      selected:
+                        count: 1
+                    add_ons:
+                      - id: full-board
+                payments:
+                  - id: pymnt-3
+                    type: PART-PAYMENT
+                    status: NOT-PAID
+                    tags:
+                      - descriptor:
+                          code: LINKED-PAYMENTS
+                        list:
+                          - descriptor:
+                              code: pymnt-4
+                            value: "1"
+                          - descriptor:
+                              code: pymnt-5
+                            value: "2"
+                  - id: pymnt-4
+                    type: PRE-ORDER
+                    collected_by: BAP
+                    tags:
+                      - descriptor:
+                          code: ADV-DEPOSIT
+                    params:
+                      amount: "2000.00"
+                      currency: INR
+                  - id: pymnt-5
+                    type: ON-FULFILLMENT
+                    collected_by: BPP
+                    tags:
+                      - descriptor:
+                          code: FINAL-PAYMENT
+                    params:
+                      amount: "1025.00"
+                      currency: INR
+                      bank_code: Bank Code of Buyer App
+                      bank_account_number: Bank Account Number of Buyer App
+                      virtual_payment_address: VPA of Buyer App
+                billing:
+                  name: Sandeep S
+                  address: Dwarka, Delhi-110075
+                  state:
+                    name: Delhi
+                  city:
+                    name: Delhi
+                  organization:
+                    descriptor:
+                      name: ONDC
+                    address: ONDC, Delhi-110049
+                  email: email@ondc.org
+                  phone: "1704380085"
+                  tax_id: GSTIN1234567890
+                fulfillments:
+                  - id: customer-1
+                    customer:
+                      person:
+                        name: Sandeep S
+                        age: "25"
+                        dob: "2023-12-20"
+                        gender: M
+                        creds:
+                          - id: AADHAAR_NO_123
+                            type: AADHAAR
+                      contact:
+                        phone: "1704380085"
+                        email: email@ondc.org
+                tags:
+                  - descriptor:
+                      code: BAP_TERMS
+                    list:
+                      - descriptor:
+                          code: STATIC_TERMS
+                        value: ""
+                      - descriptor:
+                          code: STATIC_TERMS_NEW
+                        value: >-
+                          https://github.com/ONDC-Official/NP-Static-Terms/buyerNP_BNP/1.0/tc.pdf
+                      - descriptor:
+                          code: EFFECTIVE_DATE
+                        value: "2024-01-01T00:00:00.000Z"
+                  - descriptor:
+                      code: BUYER_FINDER_FEES
+                    list:
+                      - descriptor:
+                          code: BUYER_FINDER_FEES_PERCENTAGE
+                        value: "3"
+      - summary: Provider platform accepts/appends the terms of orders
+        api: on_init
+        details:
+          - description: >-
+              Provider platform accepts the terms of orders and appends its own
+              terms and responds with the final draft
+            mermaid: |-
+              sequenceDiagram
+                participant Buyer Platform (BAP)
+                participant Seller Platform (BPP)
+                Buyer Platform (BAP)->>Seller Platform (BPP): init
+                Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+                rect rgb(191, 223, 255)
+                Seller Platform (BPP)->>Buyer Platform (BAP):on_init
+                Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+                end
+        reference: if any
+        example:
+          value: &ref_35
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: b9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: ab379fb8-cb82-4824-be12-fcbc405b6608
+              action: on_init
+              timestamp: "2023-12-20T05:28:04.408Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              order:
+                provider:
+                  id: P1
+                items:
+                  - id: Accommodation-1
+                    location_ids:
+                      - L1
+                    quantity:
+                      selected:
+                        count: 1
+                    add_ons:
+                      - id: full-board
+                quote:
+                  price:
+                    currency: INR
+                    value: "3025.00"
+                  breakup:
+                    - item:
+                        id: Accommodation-1
+                        quantity:
+                          selected:
+                            count: 1
+                        price:
+                          currency: INR
+                          value: "2000.00"
+                        add_ons:
+                          - id: full-board
+                            price:
+                              currency: INR
+                              value: "500.00"
+                      title: >-
+                        Deluxe Room accommodation with all meals included
+                        (breakfast, lunch, and dinner)
+                      price:
+                        currency: INR
+                        value: "2500.00"
+                    - title: Service Tax @ 9%
+                      price:
+                        currency: INR
+                        value: "225"
+                    - title: GST @ 12%
+                      price:
+                        currency: INR
+                        value: "300"
+                  ttl: P1D
+                payments:
+                  - id: pymnt-3
+                    type: PART-PAYMENT
+                    status: NOT-PAID
+                    tags:
+                      - descriptor:
+                          code: LINKED-PAYMENTS
+                        list:
+                          - descriptor:
+                              code: pymnt-4
+                            value: "1"
+                          - descriptor:
+                              code: pymnt-5
+                            value: "2"
+                  - id: pymnt-4
+                    type: PRE-ORDER
+                    status: NOT-PAID
+                    collected_by: BAP
+                    tags:
+                      - descriptor:
+                          code: ADV-DEPOSIT
+                    params:
+                      amount: "2000.00"
+                      currency: INR
+                      bank_code: Bank Code of Seller App
+                      bank_account_number: Bank Account Number of Seller App
+                      virtual_payment_address: " VPA of Seller App"
+                  - id: pymnt-5
+                    type: ON-FULFILLMENT
+                    status: NOT-PAID
+                    collected_by: BPP
+                    tags:
+                      - descriptor:
+                          code: FINAL-PAYMENT
+                    params:
+                      amount: "1025.00"
+                      currency: INR
+                      bank_code: Bank Code of Buyer App
+                      bank_account_number: Bank Account Number of Buyer App
+                      virtual_payment_address: VPA of Buyer App
+                billing:
+                  name: Sandeep S
+                  address: Dwarka, Delhi-110075
+                  state:
+                    name: Delhi
+                  city:
+                    name: Delhi
+                  organization:
+                    descriptor:
+                      name: ONDC
+                    address: ONDC, Delhi-110049
+                  email: email@ondc.org
+                  phone: "1704380085"
+                  tax_id: GSTIN1234567890
+                fulfillments:
+                  - id: customer-1
+                    customer:
+                      person:
+                        name: Sandeep S
+                        age: "25"
+                        dob: "2023-12-20"
+                        gender: M
+                        creds:
+                          - id: AADHAAR_NO_123
+                            type: AADHAAR
+                      contact:
+                        phone: "1704380085"
+                        email: email@ondc.org
+                tags:
+                  - descriptor:
+                      code: BAP_TERMS
+                    list:
+                      - descriptor:
+                          code: STATIC_TERMS
+                        value: ""
+                      - descriptor:
+                          code: STATIC_TERMS_NEW
+                        value: >-
+                          https://github.com/ONDC-Official/NP-Static-Terms/buyerNP_BNP/1.0/tc.pdf
+                      - descriptor:
+                          code: EFFECTIVE_DATE
+                        value: "2024-01-01T00:00:00.000Z"
+                  - descriptor:
+                      code: BUYER_FINDER_FEES
+                    list:
+                      - descriptor:
+                          code: BUYER_FINDER_FEES_PERCENTAGE
+                        value: "3"
+                  - descriptor:
+                      code: BPP_TERMS
+                    list:
+                      - descriptor:
+                          code: MAX_LIABILITY
+                        value: "2"
+                      - descriptor:
+                          code: MAX_LIABILITY_CAP
+                        value: "1000.00"
+                      - descriptor:
+                          code: MANDATORY_ARBITRATION
+                        value: "false"
+                      - descriptor:
+                          code: COURT_JURISDICTION
+                        value: New Delhi
+                      - descriptor:
+                          code: DELAY_INTEREST
+                        value: New Delhi
+                      - descriptor:
+                          code: TAX_NUMBER
+                        value: GST_NUMBER_SELLERNP
+      - summary: Consumer confirms the booking and provides details.
+        api: confirm
+        details:
+          - description: >-
+              Consumer platform confirms the booking and provides all
+              information required for confirmation as per the terms of order
+            mermaid: |-
+              sequenceDiagram
+                participant Buyer Platform (BAP)
+                participant Seller Platform (BPP)
+                rect rgb(191, 223, 255)
+                Buyer Platform (BAP)->>Seller Platform (BPP): confirm
+                Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+                end
+                Seller Platform (BPP)->>Buyer Platform (BAP):on_confirm
+                Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+        reference: if any
+        example:
+          value: &ref_28
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: b9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: ac179fb8-cb82-4824-be12-fcbc405b6608
+              action: confirm
+              timestamp: "2023-12-20T05:28:04.410Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              order:
+                provider:
+                  id: P1
+                items:
+                  - id: Accommodation-1
+                    location_ids:
+                      - L1
+                    quantity:
+                      selected:
+                        count: 1
+                    add_ons:
+                      - id: full-board
+                quote:
+                  price:
+                    currency: INR
+                    value: "3025.00"
+                  breakup:
+                    - item:
+                        id: Accommodation-1
+                        quantity:
+                          selected:
+                            count: 1
+                        price:
+                          currency: INR
+                          value: "2000.00"
+                        add_ons:
+                          - id: full-board
+                            price:
+                              currency: INR
+                              value: "500.00"
+                      title: >-
+                        Deluxe Room accommodation with all meals included
+                        (breakfast, lunch, and dinner)
+                      price:
+                        currency: INR
+                        value: "2500.00"
+                    - title: Service Tax @ 9%
+                      price:
+                        currency: INR
+                        value: "225"
+                    - title: GST @ 12%
+                      price:
+                        currency: INR
+                        value: "300"
+                  ttl: P1D
+                payments:
+                  - id: pymnt-3
+                    type: PART-PAYMENT
+                    status: NOT-PAID
+                    tags:
+                      - descriptor:
+                          code: LINKED-PAYMENTS
+                        list:
+                          - descriptor:
+                              code: pymnt-4
+                            value: "1"
+                          - descriptor:
+                              code: pymnt-5
+                            value: "2"
+                  - id: pymnt-4
+                    type: PRE-ORDER
+                    status: PAID
+                    collected_by: BAP
+                    tags:
+                      - descriptor:
+                          code: ADV-DEPOSIT
+                    params:
+                      currency: INR
+                      amount: "2000.00"
+                      transaction_id: payment-utr-1234
+                      bank_code: Bank Code of Seller App
+                      bank_account_number: Bank Account Number of Seller App
+                      virtual_payment_address: " VPA of Seller App"
+                  - id: pymnt-5
+                    type: ON-FULFILLMENT
+                    status: NOT-PAID
+                    collected_by: BPP
+                    tags:
+                      - descriptor:
+                          code: FINAL-PAYMENT
+                    params:
+                      amount: "1025.00"
+                      currency: INR
+                      bank_code: Bank Code of Buyer App
+                      bank_account_number: Bank Account Number of Buyer App
+                      virtual_payment_address: VPA of Buyer App
+                billing:
+                  name: Sandeep S
+                  address: Dwarka, Delhi-110075
+                  state:
+                    name: Delhi
+                  city:
+                    name: Delhi
+                  organization:
+                    descriptor:
+                      name: ONDC
+                    address: ONDC, Delhi-110049
+                  email: email@ondc.org
+                  phone: "1704380085"
+                  tax_id: GSTIN1234567890
+                fulfillments:
+                  - id: customer-1
+                    customer:
+                      person:
+                        name: Sandeep S
+                        age: "25"
+                        dob: "2023-12-20"
+                        gender: M
+                        creds:
+                          - id: AADHAAR_NO_123
+                            type: AADHAAR
+                      contact:
+                        phone: "1704380085"
+                        email: email@ondc.org
+                tags:
+                  - descriptor:
+                      code: BAP_TERMS
+                    list:
+                      - descriptor:
+                          code: STATIC_TERMS
+                        value: ""
+                      - descriptor:
+                          code: STATIC_TERMS_NEW
+                        value: >-
+                          https://github.com/ONDC-Official/NP-Static-Terms/buyerNP_BNP/1.0/tc.pdf
+                      - descriptor:
+                          code: EFFECTIVE_DATE
+                        value: "2024-01-01T00:00:00.000Z"
+                  - descriptor:
+                      code: BUYER_FINDER_FEES
+                    list:
+                      - descriptor:
+                          code: BUYER_FINDER_FEES_PERCENTAGE
+                        value: "3"
+                  - descriptor:
+                      code: BPP_TERMS
+                    list:
+                      - descriptor:
+                          code: MAX_LIABILITY
+                        value: "2"
+                      - descriptor:
+                          code: MAX_LIABILITY_CAP
+                        value: "1000.00"
+                      - descriptor:
+                          code: MANDATORY_ARBITRATION
+                        value: "false"
+                      - descriptor:
+                          code: COURT_JURISDICTION
+                        value: New Delhi
+                      - descriptor:
+                          code: DELAY_INTEREST
+                        value: New Delhi
+                      - descriptor:
+                          code: TAX_NUMBER
+                        value: GST_NUMBER_SELLERNP
+                created_at: "2023-12-20T05:28:04.410Z"
+                updated_at: "2023-12-20T05:28:04.410Z"
+      - summary: Provider platform confirms the order
+        api: on_confirm
+        details:
+          - description: >-
+              Provider platform confirms the order and provides details of the
+              journey upon confirmation
+            mermaid: |-
+              sequenceDiagram
+                participant Buyer Platform (BAP)
+                participant Seller Platform (BPP)
+                Buyer Platform (BAP)->>Seller Platform (BPP): confirm
+                Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+                rect rgb(191, 223, 255)
+                Seller Platform (BPP)->>Buyer Platform (BAP):on_confirm
+                Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+                end
+        reference: if any
+        example:
+          value: &ref_36
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: b9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: ac179fb8-cb82-4824-be12-fcbc405b6608
+              action: on_confirm
+              timestamp: "2023-12-20T05:28:04.415Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              order:
+                id: O1
+                status: ACTIVE
+                provider:
+                  id: P1
+                items:
+                  - id: Accommodation-1
+                    location_ids:
+                      - L1
+                    quantity:
+                      selected:
+                        count: 1
+                    add_ons:
+                      - id: full-board
+                quote:
+                  price:
+                    currency: INR
+                    value: "3025.00"
+                  breakup:
+                    - item:
+                        id: Accommodation-1
+                        quantity:
+                          selected:
+                            count: 1
+                        price:
+                          currency: INR
+                          value: "2000.00"
+                        add_ons:
+                          - id: full-board
+                            price:
+                              currency: INR
+                              value: "500.00"
+                      title: >-
+                        Deluxe Room accommodation with all meals included
+                        (breakfast, lunch, and dinner)
+                      price:
+                        currency: INR
+                        value: "2500.00"
+                    - title: Service Tax @ 9%
+                      price:
+                        currency: INR
+                        value: "225"
+                    - title: GST @ 12%
+                      price:
+                        currency: INR
+                        value: "300"
+                  ttl: P1D
+                payments:
+                  - id: pymnt-3
+                    type: PART-PAYMENT
+                    status: NOT-PAID
+                    tags:
+                      - descriptor:
+                          code: LINKED-PAYMENTS
+                        list:
+                          - descriptor:
+                              code: pymnt-4
+                            value: "1"
+                          - descriptor:
+                              code: pymnt-5
+                            value: "2"
+                  - id: pymnt-4
+                    type: PRE-ORDER
+                    status: PAID
+                    collected_by: BAP
+                    tags:
+                      - descriptor:
+                          code: ADV-DEPOSIT
+                    params:
+                      currency: INR
+                      amount: "2000.00"
+                      transaction_id: payment-utr-1234
+                      bank_code: Bank Code of Seller App
+                      bank_account_number: Bank Account Number of Seller App
+                      virtual_payment_address: " VPA of Seller App"
+                  - id: pymnt-5
+                    type: ON-FULFILLMENT
+                    status: NOT-PAID
+                    collected_by: BPP
+                    tags:
+                      - descriptor:
+                          code: FINAL-PAYMENT
+                    params:
+                      amount: "1025.00"
+                      currency: INR
+                      bank_code: Bank Code of Buyer App
+                      bank_account_number: Bank Account Number of Buyer App
+                      virtual_payment_address: VPA of Buyer App
+                billing:
+                  name: Sandeep S
+                  address: Dwarka, Delhi-110075
+                  state:
+                    name: Delhi
+                  city:
+                    name: Delhi
+                  organization:
+                    descriptor:
+                      name: ONDC
+                    address: ONDC, Delhi-110049
+                  email: email@ondc.org
+                  phone: "1704380085"
+                  tax_id: GSTIN1234567890
+                fulfillments:
+                  - id: customer-1
+                    customer:
+                      person:
+                        name: Sandeep S
+                        age: "25"
+                        dob: "2023-12-20"
+                        gender: M
+                        creds:
+                          - id: AADHAAR_NO_123
+                            type: AADHAAR
+                      contact:
+                        phone: "1704380085"
+                        email: email@ondc.org
+                tags:
+                  - descriptor:
+                      code: BAP_TERMS
+                    list:
+                      - descriptor:
+                          code: STATIC_TERMS
+                        value: ""
+                      - descriptor:
+                          code: STATIC_TERMS_NEW
+                        value: >-
+                          https://github.com/ONDC-Official/NP-Static-Terms/buyerNP_BNP/1.0/tc.pdf
+                      - descriptor:
+                          code: EFFECTIVE_DATE
+                        value: "2024-01-01T00:00:00.000Z"
+                  - descriptor:
+                      code: BUYER_FINDER_FEES
+                    list:
+                      - descriptor:
+                          code: BUYER_FINDER_FEES_PERCENTAGE
+                        value: "3"
+                  - descriptor:
+                      code: BPP_TERMS
+                    list:
+                      - descriptor:
+                          code: MAX_LIABILITY
+                        value: "2"
+                      - descriptor:
+                          code: MAX_LIABILITY_CAP
+                        value: "1000.00"
+                      - descriptor:
+                          code: MANDATORY_ARBITRATION
+                        value: "false"
+                      - descriptor:
+                          code: COURT_JURISDICTION
+                        value: New Delhi
+                      - descriptor:
+                          code: DELAY_INTEREST
+                        value: New Delhi
+                      - descriptor:
+                          code: TAX_NUMBER
+                        value: GST_NUMBER_SELLERNP
+                updated_at: "2023-12-20T05:28:04.413Z"
+      - summary: Consumer platform requests for latest status
+        api: status
+        details:
+          - description: >-
+              Consumer platform request the provider platform to provide with
+              latest order status
+            mermaid: |-
+              sequenceDiagram
+                title Order Fulfillment
+                participant Buyer Platform (BAP)
+                participant Seller Platform (BPP)
+                rect rgb(191, 223, 255)
+                Buyer Platform (BAP)->>Seller Platform (BPP): status-Request application status
+                Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+                end
+                Seller Platform (BPP)->>Buyer Platform (BAP):on_status - Provide application status
+                Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+        reference: if any
+        example:
+          value: &ref_30
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: b9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: ad786fb8-cb82-4824-be12-fcbc405b6608
+              action: status
+              timestamp: "2023-12-20T05:28:08.390Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              order_id: O1
+      - summary: Provider platform provides latest order status
+        api: on_status
+        details:
+          - description: >-
+              Provider platform provides the updated order status to the
+              consumer
+            mermaid: |-
+              sequenceDiagram
+                title Order Fulfillment
+                participant Buyer Platform (BAP)
+                participant Seller Platform (BPP)
+                Buyer Platform (BAP)->>Seller Platform (BPP): status-Request application status
+                Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+                rect rgb(191, 223, 255)
+                Seller Platform (BPP)->>Buyer Platform (BAP):on_status - Provide application status
+                Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+                end
+        reference: if any
+        example:
+          value: &ref_38
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: b9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: ad786fb8-cb82-4824-be12-fcbc405b6608
+              action: on_status
+              timestamp: "2023-12-20T05:28:10.000Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              order:
+                id: O1
+                status: COMPLETE
+                provider:
+                  id: P1
+                items:
+                  - id: Accommodation-1
+                    location_ids:
+                      - L1
+                    quantity:
+                      selected:
+                        count: 1
+                    add_ons:
+                      - id: full-board
+                quote:
+                  price:
+                    currency: INR
+                    value: "3025.00"
+                  breakup:
+                    - item:
+                        id: Accommodation-1
+                        quantity:
+                          selected:
+                            count: 1
+                        price:
+                          currency: INR
+                          value: "2000.00"
+                        add_ons:
+                          - id: full-board
+                            price:
+                              currency: INR
+                              value: "500.00"
+                      title: >-
+                        Deluxe Room accommodation with all meals included
+                        (breakfast, lunch, and dinner)
+                      price:
+                        currency: INR
+                        value: "2500.00"
+                    - title: Service Tax @ 9%
+                      price:
+                        currency: INR
+                        value: "225"
+                    - title: GST @ 12%
+                      price:
+                        currency: INR
+                        value: "300"
+                  ttl: P1D
+                payments:
+                  - id: pymnt-3
+                    type: PART-PAYMENT
+                    status: PAID
+                    tags:
+                      - descriptor:
+                          code: LINKED-PAYMENTS
+                        list:
+                          - descriptor:
+                              code: pymnt-4
+                            value: "1"
+                          - descriptor:
+                              code: pymnt-5
+                            value: "2"
+                  - id: pymnt-4
+                    type: PRE-ORDER
+                    status: PAID
+                    collected_by: BAP
+                    tags:
+                      - descriptor:
+                          code: ADV-DEPOSIT
+                    params:
+                      currency: INR
+                      amount: "2000.00"
+                      transaction_id: payment-utr-1234
+                      bank_code: Bank Code of Seller App
+                      bank_account_number: Bank Account Number of Seller App
+                      virtual_payment_address: " VPA of Seller App"
+                  - id: pymnt-5
+                    type: ON-FULFILLMENT
+                    status: PAID
+                    collected_by: BPP
+                    tags:
+                      - descriptor:
+                          code: FINAL-PAYMENT
+                    params:
+                      currency: INR
+                      amount: "1025.00"
+                      transaction_id: payment-utr-5678
+                      bank_code: Bank Code of Buyer App
+                      bank_account_number: Bank Account Number of Buyer App
+                      virtual_payment_address: VPA of Buyer App
+                    time:
+                      timestamp: "2023-12-20T05:28:09.500Z"
+                billing:
+                  name: Sandeep S
+                  address: Dwarka, Delhi-110075
+                  state:
+                    name: Delhi
+                  city:
+                    name: Delhi
+                  organization:
+                    descriptor:
+                      name: ONDC
+                    address: ONDC, Delhi-110049
+                  email: email@ondc.org
+                  phone: "1704380085"
+                  tax_id: GSTIN1234567890
+                fulfillments:
+                  - id: customer-1
+                    customer:
+                      person:
+                        name: Sandeep S
+                        age: "25"
+                        dob: "2023-12-20"
+                        gender: M
+                        creds:
+                          - id: AADHAAR_NO_123
+                            type: AADHAAR
+                      contact:
+                        phone: "1704380085"
+                        email: email@ondc.org
+                tags:
+                  - descriptor:
+                      code: BAP_TERMS
+                    list:
+                      - descriptor:
+                          code: STATIC_TERMS
+                        value: ""
+                      - descriptor:
+                          code: STATIC_TERMS_NEW
+                        value: >-
+                          https://github.com/ONDC-Official/NP-Static-Terms/buyerNP_BNP/1.0/tc.pdf
+                      - descriptor:
+                          code: EFFECTIVE_DATE
+                        value: "2024-01-01T00:00:00.000Z"
+                  - descriptor:
+                      code: BUYER_FINDER_FEES
+                    list:
+                      - descriptor:
+                          code: BUYER_FINDER_FEES_PERCENTAGE
+                        value: "3"
+                  - descriptor:
+                      code: BPP_TERMS
+                    list:
+                      - descriptor:
+                          code: MAX_LIABILITY
+                        value: "2"
+                      - descriptor:
+                          code: MAX_LIABILITY_CAP
+                        value: "1000.00"
+                      - descriptor:
+                          code: MANDATORY_ARBITRATION
+                        value: "false"
+                      - descriptor:
+                          code: COURT_JURISDICTION
+                        value: New Delhi
+                      - descriptor:
+                          code: DELAY_INTEREST
+                        value: New Delhi
+                      - descriptor:
+                          code: TAX_NUMBER
+                        value: GST_NUMBER_SELLERNP
+                documents:
+                  - descriptor:
+                      code: BOOKING_CONFIRMATION
+                    url: https://confirmation-O1.ondc.hotelbpp.com
+                  - descriptor:
+                      code: INVOICE
+                    url: https://invoice-O1.ondc.hotelbpp.com
+                updated_at: "2023-12-20T05:28:10.000Z"
+      - summary: Consumer platform updates the booking details
+        api: update
+        details:
+          - description: >-
+              The consumer platform updates the ride with some certain details
+              he wants to be updated.
+        reference: if any
+        example:
+          value: &ref_31
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: b9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: af986fb8-cb82-4824-be12-fcbc405b6608
+              action: update
+              timestamp: "2023-12-20T05:28:05.390Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              update_target: fulfillment
+              order:
+                id: O1
+                fulfillments:
+                  - id: customer-1
+                    tags:
+                      - descriptor:
+                          code: UPDATE_REQUEST
+                        list:
+                          - descriptor:
+                              code: contact.email
+                            value: newemail@ondc.org
+      - summary: Provider platform provides latest update on the order
+        api: on_update
+        details:
+          - description: >-
+              Provider platform provides the booking details with updated
+              fields.
+        reference: if any
+        example:
+          value: &ref_39
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: b9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: af986fb8-cb82-4824-be12-fcbc405b6608
+              action: on_update
+              timestamp: "2023-12-20T05:28:05.395Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              order:
+                id: O1
+                status: COMPLETE
+                provider:
+                  id: P1
+                items:
+                  - id: Accommodation-1
+                    location_ids:
+                      - L1
+                    quantity:
+                      selected:
+                        count: 1
+                    add_ons:
+                      - id: full-board
+                quote:
+                  price:
+                    currency: INR
+                    value: "3025.00"
+                  breakup:
+                    - item:
+                        id: Accommodation-1
+                        quantity:
+                          selected:
+                            count: 1
+                        price:
+                          currency: INR
+                          value: "2000.00"
+                        add_ons:
+                          - id: full-board
+                            price:
+                              currency: INR
+                              value: "500.00"
+                      title: >-
+                        Deluxe Room accommodation with all meals included
+                        (breakfast, lunch, and dinner)
+                      price:
+                        currency: INR
+                        value: "2500.00"
+                    - title: Service Tax @ 9%
+                      price:
+                        currency: INR
+                        value: "225"
+                    - title: GST @ 12%
+                      price:
+                        currency: INR
+                        value: "300"
+                  ttl: P1D
+                payments:
+                  - id: pymnt-3
+                    type: PART-PAYMENT
+                    status: PAID
+                    tags:
+                      - descriptor:
+                          code: LINKED-PAYMENTS
+                        list:
+                          - descriptor:
+                              code: pymnt-4
+                            value: "1"
+                          - descriptor:
+                              code: pymnt-5
+                            value: "2"
+                  - id: pymnt-4
+                    type: PRE-ORDER
+                    status: PAID
+                    collected_by: BAP
+                    tags:
+                      - descriptor:
+                          code: ADV-DEPOSIT
+                    params:
+                      currency: INR
+                      amount: "2000.00"
+                      transaction_id: payment-utr-1234
+                      bank_account_number: Bank Account Number of Seller App
+                      virtual_payment_address: " VPA of Seller App"
+                  - id: pymnt-5
+                    type: ON-FULFILLMENT
+                    status: PAID
+                    collected_by: BPP
+                    params:
+                      currency: INR
+                      amount: "1025.00"
+                      transaction_id: payment-utr-5678
+                      bank_account_number: Bank Account Number of Buyer App
+                      virtual_payment_address: " VPA of Buyer App"
+                    time:
+                      timestamp: "2023-12-20T05:28:09.500Z"
+                billing:
+                  name: Sandeep S
+                  address: Dwarka, Delhi-110075
+                  state:
+                    name: Delhi
+                  city:
+                    name: Delhi
+                  organization:
+                    descriptor:
+                      name: ONDC
+                    address: ONDC, Delhi-110049
+                  email: email@ondc.org
+                  phone: "1704380085"
+                  tax_id: GSTIN1234567890
+                fulfillments:
+                  - id: customer-1
+                    customer:
+                      person:
+                        name: Sandeep S
+                        age: "25"
+                        dob: "2023-12-20"
+                        gender: M
+                        creds:
+                          - id: AADHAAR_NO_123
+                            type: AADHAAR
+                      contact:
+                        phone: "1704380085"
+                        email: email@ondc.org
+                tags:
+                  - descriptor:
+                      code: BAP_TERMS
+                    list:
+                      - descriptor:
+                          code: STATIC_TERMS
+                        value: ""
+                      - descriptor:
+                          code: STATIC_TERMS_NEW
+                        value: >-
+                          https://github.com/ONDC-Official/NP-Static-Terms/buyerNP_BNP/1.0/tc.pdf
+                      - descriptor:
+                          code: EFFECTIVE_DATE
+                        value: "2024-01-01T00:00:00.000Z"
+                  - descriptor:
+                      code: BUYER_FINDER_FEES
+                    list:
+                      - descriptor:
+                          code: BUYER_FINDER_FEES_PERCENTAGE
+                        value: "3"
+                  - descriptor:
+                      code: BPP_TERMS
+                    list:
+                      - descriptor:
+                          code: MAX_LIABILITY
+                        value: "2"
+                      - descriptor:
+                          code: MAX_LIABILITY_CAP
+                        value: "1000.00"
+                      - descriptor:
+                          code: MANDATORY_ARBITRATION
+                        value: "false"
+                      - descriptor:
+                          code: COURT_JURISDICTION
+                        value: New Delhi
+                      - descriptor:
+                          code: DELAY_INTEREST
+                        value: New Delhi
+                      - descriptor:
+                          code: TAX_NUMBER
+                        value: GST_NUMBER_SELLERNP
+                documents:
+                  - descriptor:
+                      code: BOOKING_CONFIRMATION
+                    url: https://confirmation-O1.ondc.hotelbpp.com
+                  - descriptor:
+                      code: INVOICE
+                    url: https://invoice-O1.ondc.hotelbpp.com
+                updated_at: "2023-12-20T05:28:10.000Z"
+      - summary: Consumer platform cancels the request
+        api: cancel
+        details:
+          - description: >-
+              Consumer platform request the provider platform to provide with
+              latest order status
+            mermaid: |-
+              sequenceDiagram
+                title Order Fulfillment
+                participant Buyer Platform (BAP)
+                participant Seller Platform (BPP)
+                rect rgb(191, 223, 255)
+                Buyer Platform (BAP)->>Seller Platform (BPP): cancel
+                Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+                end
+                Seller Platform (BPP)->>Buyer Platform (BAP):on_cancel
+                Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+        reference: if any
+        example:
+          value: &ref_32
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: a265ecca-10b7-4d19-b640-b047a7c62200
+              message_id: a2346fb8-cb82-4824-be12-fcbc405b6608
+              action: cancel
+              timestamp: "2023-12-21T05:28:08.390Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              order_id: O1
+              cancellation_reason_id: "001"
+              descriptor:
+                short_desc: No more required
+                long_desc: Hotel available at lower price
+      - summary: Provider platform accepts/appends the terms of cancellation
+        api: on_cancel
+        details:
+          - description: >-
+              Provider platform provides the updated order status to the
+              consumer
+            mermaid: |-
+              sequenceDiagram
+                title Order Fulfillment
+                participant Buyer Platform (BAP)
+                participant Seller Platform (BPP)
+                Buyer Platform (BAP)->>Seller Platform (BPP): cancel
+                Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+                rect rgb(191, 223, 255)
+                Seller Platform (BPP)->>Buyer Platform (BAP):on_cancel
+                Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+                end
+        reference: if any
+        example:
+          value: &ref_37
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: a265ecca-10b7-4d19-b640-b047a7c62200
+              message_id: a2346fb8-cb82-4824-be12-fcbc405b6608
+              action: on_cancel
+              timestamp: "2023-12-21T05:28:08.400Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              bpp_uri: https://ondc.hotelbpp.com/
+              bpp_id: ondc.hotelbpp.com
+              ttl: PT30S
+            message:
+              order:
+                id: O2
+                status: CANCELLED
+                cancellation:
+                  cancelled_by: CONSUMER
+                  reason:
+                    id: "001"
+                    descriptor:
+                      short_desc: No more required
+                      long_desc: Hotel available at lower price
+                updated_at: "2023-12-21T05:28:08.400Z"
+  - summary: Hotel Booking (ttl based) - Flow
+    details:
+      - description: >-
+          The illustrative flow to perform a transaction of the nature where in
+          a buyer would like to book a service.
+        mermaid: |-
+          sequenceDiagram
+            title Hotel Discovery
+            Buyer Platform (BAP)->>Gateway (BG): search
+            Gateway (BG) ->> Buyer Platform (BAP): ACK
+            Gateway (BG)->>Registry: Lookup Seller Platforms (lookup)
+            Registry->>Gateway (BG): List of Seller Platforms (200 OK)
+            Gateway (BG)->>Seller Platform (BPP): search
+            Seller Platform (BPP)->>Gateway (BG) : ACK
+            Seller Platform (BPP)->>Buyer Platform (BAP): Publish Catalog of Seller 1 (on_search)
+            Buyer Platform (BAP)->>Seller Platform (BPP): ACK
+      - description: Ordering
+        mermaid: |-
+          sequenceDiagram
+            title Selection
+            participant Buyer Platform (BAP)
+            participant Seller Platform (BPP)
+            Buyer Platform (BAP)->>Seller Platform (BPP): select
+            Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+            Seller Platform (BPP)->>Buyer Platform (BAP):on_select
+            Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+      - description: Initializing the order
+        mermaid: |-
+          sequenceDiagram
+            title Initializing Order
+            participant Buyer Platform (BAP)
+            participant Seller Platform (BPP)
+            Buyer Platform (BAP)->>Seller Platform (BPP): init
+            Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+            Seller Platform (BPP)->>Buyer Platform (BAP):on_init
+            Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+      - description: Order Confirmation
+        mermaid: |-
+          sequenceDiagram
+            title  Order Confirmation
+            participant Buyer Platform (BAP)
+            participant Seller Platform (BPP)
+            Buyer Platform (BAP)->>Seller Platform (BPP): confirm
+            Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+            Seller Platform (BPP)->>Buyer Platform (BAP):on_confirm
+            Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+      - description: Fulfillment
+        mermaid: |-
+          sequenceDiagram
+            title Order Fulfillment
+            participant Buyer Platform (BAP)
+            participant Seller Platform (BPP)
+            Buyer Platform (BAP)->>Seller Platform (BPP): status-Request application status
+            Seller Platform (BPP)-->>Buyer Platform (BAP):ACK
+            Seller Platform (BPP)->>Buyer Platform (BAP):on_status - Provide application status
+            Buyer Platform (BAP)-->>Seller Platform (BPP): ACK
+    steps:
+      - summary: Search for the hotels (city-based)
+        api: search
+        details: &ref_20
+          - description: User searches over the network to avail the services
+            mermaid: |-
+              sequenceDiagram
+                rect rgb(191, 223, 255)
+                Buyer Platform (BAP)->>Gateway (BG): search
+                Gateway (BG) ->> Buyer Platform (BAP): ACK
+                Gateway (BG)->>Registry: Lookup Seller Platforms (lookup)
+                Registry->>Gateway (BG): List of Seller Platforms (200 OK)
+                Gateway (BG)->>Seller Platform (BPP): search
+                Seller Platform (BPP)->>Gateway (BG) : ACK
+                end
+                Seller Platform (BPP)->>Buyer Platform (BAP): Publish Catalog of Seller 1 (on_search)
+                Buyer Platform (BAP)->>Seller Platform (BPP): ACK
+        reference: if any
+        example:
+          summary: search by city
+          description: search by city
+          value: *ref_18
+      - summary: Get a list of all the accommodations in that particular city
+        api: on_search
+        details: &ref_21
+          - description: >-
+              Provider sends the catalog of all services that can be used for
+              hotel booking.
+            mermaid: |-
+              sequenceDiagram
+                Buyer Platform (BAP)->>Gateway (BG): search
+                Gateway (BG) ->> Buyer Platform (BAP): ACK
+                Gateway (BG)->>Registry: Lookup Seller Platforms (lookup)
+                Registry->>Gateway (BG): List of Seller Platforms (200 OK)
+                Gateway (BG)->>Seller Platform (BPP): search
+                Seller Platform (BPP)->>Gateway (BG) : ACK
+                rect rgb(191, 223, 255)
+                Seller Platform (BPP)->>Buyer Platform (BAP): Publish Catalog of Seller 1 (on_search)
+                Buyer Platform (BAP)->>Seller Platform (BPP): ACK
+                end
+        reference: if any
+        example: &ref_22
+          value: *ref_19
+      - summary: Search for the hotels (ttl based with time range)
+        api: search
+        details: *ref_20
+        reference: if any
+        example:
+          summary: search by city (ttl based)
+          description: search by city (ttl based)
+          value: &ref_26
+            context:
+              domain: ONDC:TRV13
+              location:
+                country:
+                  code: IND
+                city:
+                  code: std:080
+              transaction_id: a9aaecca-10b7-4d19-b640-b047a7c62196
+              message_id: bb579fb8-cb82-4824-be12-fcbc405b6608
+              action: search
+              timestamp: "2023-12-20T05:23:03.443Z"
+              version: 2.0.0
+              bap_uri: https://ondc.hotelbap.com/
+              bap_id: ondc.hotelbap.com
+              ttl: P7D
+            message:
+              intent:
+                category:
+                  descriptor:
+                    code: HOTEL
+                  time:
+                    label: AVAILABLE
+                    range:
+                      start: "2024-01-10T00:00:00.000Z"
+                      end: "2024-01-15T00:00:00.000Z"
+                fulfillment:
+                  stops:
+                    - type: END
+                      location:
+                        gps: 12.82735998361846, 77.69157068978166
+                        area_code: "560100"
+                tags:
+                  - descriptor:
+                      code: BAP_TERMS
+                    list:
+                      - descriptor:
+                          code: STATIC_TERMS
+                        value: ""
+                      - descriptor:
+                          code: STATIC_TERMS_NEW
+                        value: >-
+                          https://github.com/ONDC-Official/static-terms//buyerNP_BNP/1.0/tc.pdf
+                      - descriptor:
+                          code: EFFECTIVE_DATE
+                        value: "2024-01-01T00:00:00.000Z"
+                  - descriptor:
+                      code: BUYER_FINDER_FEES
+                    list:
+                      - descriptor:
+                          code: BUYER_FINDER_FEES_PERCENTAGE
+                        value: "3"
+      - summary: Get a list of all the available accommodations
+        api: on_search
+        details: *ref_21
+        reference: if any
+        example: *ref_22
+x-examples:
+  hotel:
+    summary: Hotel Use Case Specification
+    description: Hotel Use Case Specification
+    example_set:
+      search:
+        examples:
+          - summary: search_by_city
+            description: search by city
+            value: *ref_18
+          - summary: search_for_the_availability(with_time_range)
+            description: Search for the availability of accommodation (with time range)
+            value: *ref_23
+          - summary: search_by_provider
+            description: search by provider (id or name)
+            value: *ref_24
+          - summary: incremental_search
+            description: incremental search
+            value: *ref_25
+          - summary: search_by_city_(ttl_based)
+            description: search by city (ttl based)
+            value: *ref_26
+      select:
+        examples:
+          - summary: selectundefined
+            value: *ref_27
+      confirm:
+        examples:
+          - summary: confirmundefined
+            value: *ref_28
+      init:
+        examples:
+          - summary: initundefined
+            value: *ref_29
+      status:
+        examples:
+          - summary: statusundefined
+            value: *ref_30
+      update:
+        examples:
+          - summary: updateundefined
+            value: *ref_31
+      support:
+        examples:
+          - summary: supportundefined
+            value:
+              context:
+                domain: ONDC:TRV13
+                location:
+                  country:
+                    code: IND
+                  city:
+                    code: std:080
+                transaction_id: b9aaecca-10b7-4d19-b640-b047a7c62196
+                message_id: af900fb8-cb82-4824-be12-fcbc405b6608
+                action: support
+                timestamp: "2023-12-20T05:28:06.390Z"
+                version: 2.0.0
+                bap_uri: https://ondc.hotelbap.com/
+                bap_id: ondc.hotelbap.com
+                bpp_uri: https://ondc.hotelbpp.com/
+                bpp_id: ondc.hotelbpp.com
+                ttl: PT30S
+              message:
+                ref_id: O1
+      cancel:
+        examples:
+          - summary: cancelundefined
+            value: *ref_32
+      on_search:
+        examples:
+          - summary: on_searchundefined
+            value: *ref_19
+          - summary: on_searchundefined_2
+            value: *ref_33
+          - summary: on_searchundefined_3
+            value:
+              context:
+                domain: ONDC:TRV13
+                location:
+                  country:
+                    code: IND
+                  city:
+                    code: std:080
+                transaction_id: a9aaecca-10b7-4d19-b640-b047a7c62196
+                message_id: bb579fb8-cb82-4824-be12-fcbc405b6608
+                action: on_search
+                timestamp: "2023-12-20T05:28:04.300Z"
+                version: 2.0.0
+                bap_uri: https://ondc.hotelbap.com/
+                bap_id: ondc.hotelbap.com
+                bpp_uri: https://ondc.hotelbpp.com/
+                bpp_id: ondc.hotelbpp.com
+                ttl: PT30S
+              message:
+                catalog:
+                  descriptor:
+                    name: ONDC Hotel Groups
+                    code: BPP Code
+                    short_desc: Hotel BPP ONDC
+                    long_desc: "ONDC Hotel Groups is a Hotel Aggregator "
+                    images:
+                      - url: https://remote-image.ondc.hotelbpp.com
+                  providers:
+                    - id: P1
+                      time:
+                        label: ENABLE
+                        timestamp: "2023-12-20T05:28:04.300Z"
+                      descriptor:
+                        name: ONDC Hotel Provider ABC
+                        code: Hotel
+                        short_desc: Hotel ABC ONDC is a renowned hotel provider in India
+                        long_desc: >-
+                          Hotel ABC ONDC Provider is equipped with a variety of
+                          on-site amenities to enhance the overall quality and
+                          enjoyment of your experience
+                        images:
+                          - url: https://remote-image-ABC.ondc.hotelbpp.com
+                          - url: https://remote-image-ABC-2.ondc.hotelbpp.com
+                      locations:
+                        - id: L1
+                          gps: 12.88984957221858, 78.00666372461477
+                          address: M.Hosahalli
+                          city:
+                            name: Bangalore
+                          state:
+                            name: Karnataka
+                          area_code: "563139"
+                          rating: "5"
+                      categories:
+                        - id: dlx-1234
+                          descriptor:
+                            name: Deluxe Room
+                        - id: fml-ste
+                          descriptor:
+                            name: Family Suite
+                      payments:
+                        - id: pymnt-1
+                          type: PRE-ORDER
+                        - id: pymnt-2
+                          type: ON-FULFILLMENT
+                        - id: pymnt-3
+                          type: PART-PAYMENT
+                      items:
+                        - id: Accommodation-1
+                          time:
+                            label: ENABLE
+                            timestamp: "2023-12-20T05:28:04.300Z"
+                          descriptor:
+                            name: Deluxe Room
+                            code: DELUXE
+                            additional_desc:
+                              url: >-
+                                https://remote-image-Acc-1-details.ondc.hotelbpp.com
+                              content_type: application/json
+                            images:
+                              - url: https://remote-image-Acc-1-1.ondc.hotelbpp.com
+                              - url: https://remote-image-Acc-1-2.ondc.hotelbpp.com
+                          price:
+                            currency: INR
+                            value: "2000.00"
+                            maximum_value: "3000.00"
+                          quantity:
+                            available:
+                              count: 12
+                            maximum:
+                              count: 4
+                          location_ids:
+                            - L1
+                          category_ids:
+                            - dlx-1234
+                          payment_ids:
+                            - pymnt-1
+                            - pymnt-2
+                            - pymnt-3
+                          add_ons:
+                            - id: B&B
+                              descriptor:
+                                name: Breakfast Included
+                                short_desc: Accommodation with breakfast included
+                              price:
+                                currency: INR
+                                value: "200.00"
+                                maximum_value: "300.00"
+                            - id: full-board
+                              descriptor:
+                                name: Full Board
+                                short_desc: >-
+                                  Accommodation with all meals included
+                                  (breakfast, lunch, and dinner)
+                              price:
+                                currency: INR
+                                value: "500.00"
+                                maximum_value: "700.00"
+                            - id: extra-bed-child
+                              descriptor:
+                                name: child bed
+                                short_desc: Accomodation with extra child bed
+                              price:
+                                currency: INR
+                                value: "200.00"
+                                maximum_value: "300.00"
+                            - id: extra-bed-adult
+                              descriptor:
+                                name: adult bed
+                                short_desc: Accomodation with extra adult bed
+                              price:
+                                currency: INR
+                                value: "300.00"
+                                maximum_value: "500.00"
+                          cancellation_terms:
+                            - external_ref:
+                                mimetype: application/json
+                                url: https://remote-terms-ABC.ondc.hotelbpp.com
+                          recommended: true
+                        - id: Accommodation-2
+                          time:
+                            label: ENABLE
+                            timestamp: "2023-12-20T05:28:04.300Z"
+                            duration: PT2H
+                            range:
+                              start: "2023-12-20T05:28:04.300Z"
+                              end: "2023-12-20T06:28:04.300Z"
+                          descriptor:
+                            name: Family Suite
+                            code: SUITE
+                            additional_desc:
+                              url: >-
+                                https://remote-image-Acc-2-details.ondc.hotelbpp.com
+                              content_type: application/json
+                            images:
+                              - url: https://remote-image-Acc-2-1.ondc.hotelbpp.com
+                              - url: https://remote-image-Acc-2-2.ondc.hotelbpp.com
+                          price:
+                            currency: INR
+                            value: "7000.00"
+                            maximum_value: "8000.00"
+                          quantity:
+                            available:
+                              count: 2
+                            maximum:
+                              count: 1
+                          location_ids:
+                            - L1
+                          category_ids:
+                            - fml-ste
+                          payment_ids:
+                            - pymnt-1
+                          add_ons:
+                            - id: full-board
+                              descriptor:
+                                name: Full Board
+                                short_desc: >-
+                                  Accommodation with all meals included
+                                  (breakfast, lunch, and dinner)
+                              price:
+                                currency: INR
+                                value: "3000.00"
+                                maximum_value: "4000.00"
+                          cancellation_terms:
+                            - external_ref:
+                                mimetype: application/json
+                                url: https://remote-terms-ABC.ondc.hotelbpp.com
+                          recommended: true
+      on_select:
+        examples:
+          - summary: on_selectundefined
+            value: *ref_34
+      on_init:
+        examples:
+          - summary: on_initundefined
+            value: *ref_35
+      on_confirm:
+        examples:
+          - summary: on_confirmundefined
+            value: *ref_36
+      on_cancel:
+        examples:
+          - summary: on_cancelundefined
+            value: *ref_37
+      on_status:
+        examples:
+          - summary: on_statusundefined
+            value: *ref_38
+      on_support:
+        examples:
+          - summary: on_supportundefined
+            value:
+              context:
+                domain: ONDC:TRV13
+                location:
+                  country:
+                    code: IND
+                  city:
+                    code: std:080
+                transaction_id: b9aaecca-10b7-4d19-b640-b047a7c62196
+                message_id: af900fb8-cb82-4824-be12-fcbc405b6608
+                action: on_support
+                timestamp: "2023-12-20T05:28:06.400Z"
+                version: 2.0.0
+                bap_uri: https://ondc.hotelbap.com/
+                bap_id: ondc.hotelbap.com
+                bpp_uri: https://ondc.hotelbpp.com/
+                bpp_id: ondc.hotelbpp.com
+                ttl: PT30S
+              message:
+                ref_id: O1
+                phone: "0112323232"
+                email: help@hotelbpp.com
+      on_update:
+        examples:
+          - summary: on_updateundefined
+            value: *ref_39
+x-attributes:
+  hotel:
+    attribute_set:
+      search:
+        context:
+          location: &ref_41
+            country:
+              code:
+                required: MANDATORY
+                type: string
+                owner: BAP
+                usage: IND
+                description: Describes country code as per ISO 3166-1 and ISO 3166-2 format
+            city:
+              code:
+                required: MANDATORY
+                type: string
+                owner: BAP
+                usage: std:080
+                description: Describes the city code this location is, or is located within
+          domain: &ref_42
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: ONDC:TRV13
+            description: Describes domain code that is relevant to this transaction context
+          timestamp: &ref_43
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: 2023-03-23T04:41:16.000Z
+            description: Describes tme of request generation in RFC3339 format
+          bap_id: &ref_44
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: ondc.hotelbap.com
+            description: Describes subscriber ID of the BAP
+          transaction_id: &ref_45
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: 6743e9e2
+            description: Describes  a unique value which persists across all API calls
+          message_id: &ref_46
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: 13ba8018f176
+            description: >-
+              Describes a unique value which persists during a request /
+              callback cycle.
+          version: &ref_47
+            required: MANDATORY
+            type: integer
+            owner: BAP
+            usage: 2.0.0
+            description: >-
+              Describes the version of transaction protocol being used by the
+              sender.
+          action: &ref_48
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: search
+            description: >-
+              Describes the Beckn protocol method being called by the sender and
+              executed at the receiver.
+          bap_uri: &ref_49
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: https://ondc.hotelbap.com/
+            description: >-
+              Describes subscriber URL of the BAP for accepting callbacks from
+              BPPs.
+          ttl: &ref_50
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: PT30S
+            description: >-
+              Describes the duration in ISO8601 format after timestamp for which
+              this message holds valid
+        message:
+          intent:
+            category:
+              descriptor:
+                code:
+                  required: MANDATORY
+                  type: string
+                  owner: BAP
+                  usage: HOTEL
+                  description: Describes the category code for search's intent.
+              time: &ref_40
+                label:
+                  required: OPTIONAL
+                  type: string
+                  owner: BAP
+                  usage: AVAILABLE
+                  description: Describes the category code for search's intent.
+                range:
+                  start:
+                    required: OPTIONAL
+                    type: string
+                    owner: BAP
+                    usage: 2023-12-25T00:00:00.000Z
+                    description: Describes the category code for search's intent.
+                  end:
+                    required: OPTIONAL
+                    type: string
+                    owner: BAP
+                    usage: 2023-12-27T00:00:00.000Z
+                    description: Describes the category code for search's intent.
+            fulfillment:
+              stops:
+                type:
+                  required: OPTIONAL
+                  type: string
+                  owner: BAP
+                  usage: END
+                  description: >-
+                    The type of stop. Allowed values of this property can be
+                    defined by the network policy.
+                location:
+                  gps:
+                    required: OPTIONAL
+                    type: string
+                    owner: BAP
+                    usage: 12.8273599836184
+                    description: The GPS co-ordinates of this location.
+                  area_code:
+                    required: OPTIONAL
+                    type: string
+                    owner: BAP
+                    usage: 560100
+                    description: Describes the area code of the location.
+            provider:
+              time: *ref_40
+              id:
+                required: OPTIONAL
+                type: string
+                owner: BAP
+                usage: ondc-hotel-provider1
+                description: Describes the provider id.
+      on_search:
+        context:
+          location: *ref_41
+          domain: *ref_42
+          timestamp: *ref_43
+          bap_id: *ref_44
+          transaction_id: *ref_45
+          message_id: *ref_46
+          version: *ref_47
+          action: *ref_48
+          bap_uri: *ref_49
+          bpp_uri: &ref_51
+            required: MANDATORY
+            type: string
+            owner: BPP
+            usage: " https://ondc.hotelbpp.com/"
+            description: Describes subscriber URL of the BPP for accepting calls from BAPs.
+          bpp_id: &ref_52
+            required: MANDATORY
+            type: string
+            owner: BPP
+            usage: ondc.hotelbpp.com
+            description: Describes subscriber ID of the BPP
+          ttl: *ref_50
+        message:
+          catalog:
+            descriptor:
+              name:
+                required: OPTIONAL
+                type: string
+                owner: BPP
+                usage: ONDC Hotel Groups
+                description: Describes the catalogs name.
+              code:
+                required: OPTIONAL
+                type: string
+                owner: BPP
+                usage: BPP Code
+                description: Describes the catalogs code.
+              short_desc:
+                required: OPTIONAL
+                type: string
+                owner: BPP
+                usage: Hotel BPP ONDC
+                description: Describes the catalogs short description.
+              long_desc:
+                required: OPTIONAL
+                type: string
+                owner: BPP
+                usage: ONDC Hotel Groups is a Hotel Aggregator
+                description: Describes the catalogs long description.
+              images:
+                url:
+                  required: OPTIONAL
+                  type: string
+                  owner: BPP
+                  usage: https://remote-image.ondc.hotelbpp.com
+                  description: Describes the image URL for catalog.
+            providers:
+              id:
+                required: MANDATORY
+                type: string
+                owner: BPP
+                usage: P1
+                description: Describes the unique id of provider
+              descriptor:
+                name:
+                  required: OPTIONAL
+                  type: string
+                  owner: BPP
+                  usage: ONDC Hotel Provider ABC
+                  description: Describes the name of the provider.
+                short_desc:
+                  required: OPTIONAL
+                  type: string
+                  owner: BPP
+                  usage: Hotel ABC ONDC is a renowned hotel provider in India
+                  description: Describes the short description of the provider.
+                long_desc:
+                  required: OPTIONAL
+                  type: string
+                  owner: BPP
+                  usage: >-
+                    All the hotels in ABC ONDC Hotel Provider are equipped with
+                    a variety
+                                  of on-site amenities
+                  description: Describes the long description of the provider.
+                images:
+                  url:
+                    required: OPTIONAL
+                    type: string
+                    owner: BPP
+                    usage: https://remote-image-ABC.ondc.hotelbpp.com
+                    description: URL to the image. This can be a data url or an remote url
+              locations:
+                id:
+                  required: OPTIONAL
+                  type: string
+                  owner: BPP
+                  usage: L1
+                  description: Describes the serviceable location of the provider.
+                descriptor:
+                  name:
+                    required: OPTIONAL
+                    type: string
+                    owner: BPP
+                    usage: ONDC Hotel H1
+                    description: Describes the name of location.
+                  code:
+                    required: OPTIONAL
+                    type: string
+                    owner: BPP
+                    usage: Hotel:5
+                    description: Describes the code of location.
+                  short_desc:
+                    required: OPTIONAL
+                    type: string
+                    owner: BPP
+                    usage: Hotel ABC ONDC is a renowned hotel in India
+                    description: Describes the short description of location.
+                  long_desc:
+                    required: OPTIONAL
+                    type: string
+                    owner: BPP
+                    usage: >-
+                      ABC ONDC Hotel establishment is equipped with a variety of
+                      on-site
+                       amenities
+                    description: Describes the long description of location.
+                  images:
+                    url:
+                      required: OPTIONAL
+                      type: string
+                      owner: BPP
+                      usage: https://remote-image-H1-1.ondc.hotelbpp.com
+                      description: >-
+                        URL to the image. This can be a data url or an remote
+                        url
+                gps:
+                  required: OPTIONAL
+                  type: string
+                  owner: BPP
+                  usage: 12.889849
+                  description: Describes the gps co-ordinates of the location.
+                address:
+                  required: OPTIONAL
+                  type: string
+                  owner: BPP
+                  usage: M.Hosahalli
+                  description: Describes the address of the location.
+                city:
+                  name:
+                    required: OPTIONAL
+                    type: string
+                    owner: BPP
+                    usage: Bangalore
+                    description: Describes the city's name of the location.
+                state:
+                  name:
+                    required: OPTIONAL
+                    type: string
+                    owner: BPP
+                    usage: Karnataka
+                    description: Describes the state's name of the location.
+                area_code:
+                  required: OPTIONAL
+                  type: string
+                  owner: BPP
+                  usage: 563139
+                  description: Describes the area code of the location.
+              payments:
+                id:
+                  required: OPTIONAL
+                  type: string
+                  owner: BPP
+                  usage: pymnt-1
+                  description: Describes the payment ID.
+                type:
+                  required: OPTIONAL
+                  type: string
+                  owner: BPP
+                  usage: PRE-ORDER
+                  description: Describes the payment type.
+              items:
+                id: &ref_54
+                  required: MANDATORY
+                  type: string
+                  owner: BPP
+                  usage: Accommodation-1
+                  description: Describes the item ID.
+                time:
+                  label: &ref_53
+                    required: MANDATORY
+                    type: string
+                    owner: BPP
+                    usage: ENABLE
+                    description: Describes the time's label.
+                  timestamp:
+                    required: MANDATORY
+                    type: string
+                    owner: BPP
+                    usage: 2023-12-20T05:28:04.300Z
+                    description: Describes the timestamp.
+                descriptor:
+                  code:
+                    required: MANDATORY
+                    type: string
+                    owner: BPP
+                    usage: DELUXE
+                    description: Describes the code for a particular item.
+                  name:
+                    required: MANDATORY
+                    type: string
+                    owner: BPP
+                    usage: Deluxe Room
+                    description: Describes the name for a particular item.
+                  additional_desc:
+                    url:
+                      required: OPTIONAL
+                      type: string
+                      owner: BPP
+                      usage: https://remote-image-Acc-1-details.ondc.hotelbpp.com
+                      description: >-
+                        Describes the additional description for a particular
+                        item.
+                    content_type:
+                      required: OPTIONAL
+                      type: string
+                      owner: BPP
+                      usage: application/json
+                      description: Describes the content type for a particular item.
+                  images:
+                    url:
+                      required: OPTIONAL
+                      type: string
+                      owner: BPP
+                      usage: https://remote-image-Acc-1-1.ondc.hotelbpp.com
+                      description: Describes the image URL for item.
+                price:
+                  currency:
+                    required: MANDATORY
+                    type: string
+                    owner: BPP
+                    usage: INR
+                    description: Describes the price of a product or service
+                  value:
+                    required: MANDATORY
+                    type: string
+                    owner: BPP
+                    usage: 2000
+                    description: Describes the currency of a product or service
+                  maximum_value:
+                    required: MANDATORY
+                    type: string
+                    owner: BPP
+                    usage: 3000
+                    description: Describes the maximum value of a product or service
+                quantity:
+                  available:
+                    count:
+                      required: MANDATORY
+                      type: integer
+                      owner: BPP
+                      usage: 12
+                      description: >-
+                        Describes the available count value of a product or
+                        service
+                  maximum:
+                    count:
+                      required: MANDATORY
+                      type: integer
+                      owner: BPP
+                      usage: 12
+                      description: >-
+                        Describes the maximum count value of a product or
+                        service
+                location_ids:
+                  required: MANDATORY
+                  type: string
+                  owner: BPP
+                  usage: L1
+                  description: Describes the location id of a product or service
+                payment_ids:
+                  required: MANDATORY
+                  type: string
+                  owner: BPP
+                  usage: pymnt-1
+                  description: Describes the payment id of a product or service
+                add_ons:
+                  id:
+                    required: MANDATORY
+                    type: string
+                    owner: BPP
+                    usage: B&B
+                    description: Describes the add_ons id.
+                  descriptor:
+                    name:
+                      required: MANDATORY
+                      type: string
+                      owner: BPP
+                      usage: Breakfast Included
+                      description: Describes the descriptior name.
+                  price:
+                    currency:
+                      required: MANDATORY
+                      type: string
+                      owner: BPP
+                      usage: INR
+                      description: Describes the price's currency.
+                    value:
+                      required: MANDATORY
+                      type: string
+                      owner: BPP
+                      usage: 200
+                      description: Describes the price's value.
+                    maximum_value:
+                      required: MANDATORY
+                      type: string
+                      owner: BPP
+                      usage: 300
+                      description: Describes the price's maximum value.
+      select:
+        context:
+          location: *ref_41
+          domain: *ref_42
+          timestamp: *ref_43
+          bap_id: *ref_44
+          transaction_id: *ref_45
+          message_id: *ref_46
+          version: *ref_47
+          action:
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: select
+            description: >-
+              Describes the Beckn protocol method being called by the sender and
+              executed at the receiver.
+          bap_uri: *ref_49
+          bpp_uri: *ref_51
+          bpp_id: *ref_52
+          ttl: *ref_50
+        message:
+          order:
+            provider:
+              id: &ref_55
+                required: MANDATORY
+                type: string
+                owner: BPP
+                usage: P1
+                description: Describes the provider ID.
+              time:
+                label: *ref_53
+                range:
+                  start:
+                    required: MANDATORY
+                    type: string
+                    owner: BAP
+                    usage: 2023-12-25T00:00:00.000Z
+                    description: Describes the category code for search's intent.
+                  end:
+                    required: MANDATORY
+                    type: string
+                    owner: BAP
+                    usage: 2023-12-27T00:00:00.000Z
+                    description: Describes the category code for search's intent.
+            items: &ref_58
+              id: *ref_54
+              location_ids:
+                required: MANDATORY
+                type: string
+                owner: BPP
+                usage: L1
+                description: Describes the location ID.
+              quantity: &ref_61
+                selected:
+                  count:
+                    required: MANDATORY
+                    type: string
+                    owner: BAP
+                    usage: 1
+                    description: Describes quantity count of the selected item.
+              add_ons: &ref_56
+                id:
+                  required: MANDATORY
+                  type: string
+                  owner: BPP
+                  usage: full-board
+                  description: Describes add_ons id the selected item.
+      on_select:
+        context:
+          location: *ref_41
+          domain: *ref_42
+          timestamp: *ref_43
+          bap_id: *ref_44
+          transaction_id: *ref_45
+          message_id: *ref_46
+          version: *ref_47
+          action:
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: on_select
+            description: >-
+              Describes the Beckn protocol method being called by the sender and
+              executed at the receiver.
+          bap_uri: *ref_49
+          bpp_uri: *ref_51
+          bpp_id: *ref_52
+          ttl: *ref_50
+        message:
+          order:
+            provider: &ref_57
+              id: *ref_55
+            items:
+              id: *ref_54
+              add_ons: *ref_56
+            quote: &ref_62
+              price:
+                currency:
+                  required: MANDATORY
+                  type: string
+                  owner: BPP
+                  usage: INR
+                  description: Describes currency type of the price
+                value:
+                  required: MANDATORY
+                  type: string
+                  owner: BPP
+                  usage: 3025
+                  description: Describes price value.
+              breakup:
+                item:
+                  id:
+                    required: OPTIONAL
+                    type: string
+                    owner: BPP
+                    usage: 3025
+                    description: Describes price value.
+                  quantity:
+                    selected:
+                      count:
+                        required: OPTIONAL
+                        type: string
+                        owner: BPP
+                        usage: 1
+                        description: Describes the selected count for breakup.
+                  price:
+                    currency:
+                      required: OPTIONAL
+                      type: string
+                      owner: BPP
+                      usage: INR
+                      description: Describes the breakup price.
+                    value:
+                      required: OPTIONAL
+                      type: string
+                      owner: BPP
+                      usage: 2000
+                      description: Describes the breakup currency.
+                  add_ons:
+                    id:
+                      required: OPTIONAL
+                      type: string
+                      owner: BPP
+                      usage: full-board
+                      description: Describes the add_ons id
+                    price:
+                      currency:
+                        required: OPTIONAL
+                        type: string
+                        owner: BPP
+                        usage: INR
+                        description: Describes the currency for add_on
+                      value:
+                        required: OPTIONAL
+                        type: string
+                        owner: BPP
+                        usage: 500
+                        description: Describes the price for add_on
+                title:
+                  required: MANDATORY
+                  type: string
+                  owner: BPP
+                  usage: Deluxe Room accommodation with all meals included
+                  description: Describes the title for breakup.
+                price:
+                  currency:
+                    required: MANDATORY
+                    type: string
+                    owner: BPP
+                    usage: INR
+                    description: Describes the currency for breakup
+                  value:
+                    required: MANDATORY
+                    type: string
+                    owner: BPP
+                    usage: 2500
+                    description: Describes the price for breakup
+            payments:
+              id: &ref_59
+                required: MANDATORY
+                type: string
+                owner: BPP
+                usage: " pymnt-1"
+                description: Describes the payment id.
+              type: &ref_60
+                required: MANDATORY
+                type: string
+                owner: BPP
+                usage: PRE-ORDER
+                description: Describes the payment type.
+      init:
+        context:
+          location: *ref_41
+          domain: *ref_42
+          timestamp: *ref_43
+          bap_id: *ref_44
+          transaction_id: *ref_45
+          message_id: *ref_46
+          version: *ref_47
+          action:
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: init
+            description: >-
+              Describes the Beckn protocol method being called by the sender and
+              executed at the receiver.
+          bap_uri: *ref_49
+          bpp_uri: *ref_51
+          bpp_id: *ref_52
+          ttl: *ref_50
+        message:
+          order:
+            provider: *ref_57
+            items: *ref_58
+            payments:
+              id: *ref_59
+              type: *ref_60
+              status:
+                required: OPTIONAL
+                type: string
+                owner: BAP
+                usage: NOT-PAID
+                description: Describes the payment status.
+              collected_by: &ref_63
+                required: OPTIONAL
+                type: string
+                owner: BAP
+                usage: BAP
+                description: Describes the payment's collection mode.
+              params: &ref_64
+                bank_account_number: &ref_68
+                  required: OPTIONAL
+                  type: string
+                  owner: BAP
+                  usage: 12421I24
+                  description: Describes the bank account number.
+                virtual_payment_address: &ref_69
+                  required: OPTIONAL
+                  type: string
+                  owner: BAP
+                  usage: sds@okicic.in
+                  description: Describes the virtual payment address.
+            billing: &ref_65
+              name: &ref_76
+                required: MANDATORY
+                type: string
+                owner: BAP
+                usage: Sandeep S
+                description: Describes the billing name.
+              address:
+                required: MANDATORY
+                type: string
+                owner: BAP
+                usage: Dwarka, Delhi-110075
+                description: Describes the billing address.
+              state: &ref_77
+                name:
+                  required: MANDATORY
+                  type: string
+                  owner: BAP
+                  usage: Delhi
+                  description: Describes the billing's state name.
+              city: &ref_78
+                name:
+                  required: MANDATORY
+                  type: string
+                  owner: BAP
+                  usage: Delhi
+                  description: Describes the billing city name.
+              organization: &ref_79
+                descriptor:
+                  name:
+                    required: MANDATORY
+                    type: string
+                    owner: BAP
+                    usage: ONDC
+                    description: Describes the organization name.
+                address:
+                  required: MANDATORY
+                  type: string
+                  owner: BAP
+                  usage: ONDC, Delhi-110049
+                  description: Describes the organization address.
+              email: &ref_80
+                required: MANDATORY
+                type: string
+                owner: BAP
+                usage: email@ondc.org
+                description: Describes the billing email.
+              phone: &ref_81
+                required: MANDATORY
+                type: string
+                owner: BAP
+                usage: ONDC, Delhi-110049
+                description: Describes the billing phone.
+              tax_id: &ref_82
+                required: MANDATORY
+                type: string
+                owner: BAP
+                usage: GSTIN1234567890
+                description: Describes the tax id.
+            fulfillments: &ref_66
+              id:
+                required: MANDATORY
+                type: string
+                owner: BAP
+                usage: customer-1
+                description: Describes the fulfillments id.
+              customer:
+                person:
+                  name:
+                    required: MANDATORY
+                    type: string
+                    owner: BAP
+                    usage: Sandeep S
+                    description: Describes the customer name for fulfillments.
+                  age:
+                    required: MANDATORY
+                    type: string
+                    owner: BAP
+                    usage: 25
+                    description: Describes the customer age for fulfillments.
+                  gender:
+                    required: MANDATORY
+                    type: string
+                    owner: BAP
+                    usage: M
+                    description: Describes the customer gender for fulfillments.
+                  dob:
+                    required: MANDATORY
+                    type: string
+                    owner: BAP
+                    usage: 45280
+                    description: Describes the customer age for fulfillments.
+                  creds:
+                    id:
+                      required: OPTIONAL
+                      type: string
+                      owner: BAP
+                      usage: AADHAAR_NO_123
+                      description: Describes the customer credentials for fulfillments.
+                    type:
+                      required: OPTIONAL
+                      type: string
+                      owner: BAP
+                      usage: AADHAAR
+                      description: >-
+                        Describes the customer credentials type for
+                        fulfillments.
+                contact:
+                  phone:
+                    required: MANDATORY
+                    type: string
+                    owner: BAP
+                    usage: 1704380085
+                    description: Describes the customer contact number for fulfillments.
+                  email:
+                    required: MANDATORY
+                    type: string
+                    owner: BAP
+                    usage: 1704380085
+                    description: Describes the customer email for fulfillments.
+      on_init:
+        context:
+          location: *ref_41
+          domain: *ref_42
+          timestamp: *ref_43
+          bap_id: *ref_44
+          transaction_id: *ref_45
+          message_id: *ref_46
+          version: *ref_47
+          action:
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: on_init
+            description: >-
+              Describes the Beckn protocol method being called by the sender and
+              executed at the receiver.
+          bap_uri: *ref_49
+          bpp_uri: *ref_51
+          bpp_id: *ref_52
+          ttl: *ref_50
+        message:
+          order:
+            provider: *ref_57
+            items: &ref_70
+              id: *ref_54
+              add_ons: *ref_56
+              quantity: *ref_61
+            quote: *ref_62
+            payments:
+              id: *ref_59
+              type: *ref_60
+              status: &ref_67
+                required: MANDATORY
+                type: string
+                owner: BAP
+                usage: NOT-PAID
+                description: Describes the payment status.
+              collected_by: *ref_63
+              params: *ref_64
+            billing: *ref_65
+            fulfillments: *ref_66
+      confirm:
+        context:
+          location: *ref_41
+          domain: *ref_42
+          timestamp: *ref_43
+          bap_id: *ref_44
+          transaction_id: *ref_45
+          message_id: *ref_46
+          version: *ref_47
+          action:
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: confirm
+            description: >-
+              Describes the Beckn protocol method being called by the sender and
+              executed at the receiver.
+          bap_uri: *ref_49
+          bpp_uri: *ref_51
+          bpp_id: *ref_52
+          ttl: *ref_50
+        message:
+          order:
+            provider: *ref_57
+            items: *ref_58
+            payments: &ref_71
+              id: *ref_59
+              type: *ref_60
+              status: *ref_67
+              collected_by: *ref_63
+              params:
+                bank_account_number: *ref_68
+                virtual_payment_address: *ref_69
+                currency:
+                  required: OPTIONAL
+                  type: string
+                  owner: BAP
+                  usage: INR
+                  description: Describes the currency.
+                amount:
+                  required: OPTIONAL
+                  type: string
+                  owner: BAP
+                  usage: INR
+                  description: Describes the amount.
+                transaction_id:
+                  required: OPTIONAL
+                  type: string
+                  owner: BAP
+                  usage: INR
+                  description: Describes the transaction id.
+            billing: *ref_65
+            fulfillments: *ref_66
+      on_confirm:
+        context:
+          location: *ref_41
+          domain: *ref_42
+          timestamp: *ref_43
+          bap_id: *ref_44
+          transaction_id: *ref_45
+          message_id: *ref_46
+          version: *ref_47
+          action:
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: on_confirm
+            description: >-
+              Describes the Beckn protocol method being called by the sender and
+              executed at the receiver.
+          bap_uri: *ref_49
+          bpp_uri: *ref_51
+          bpp_id: *ref_52
+          ttl: *ref_50
+        message:
+          order:
+            id: &ref_72
+              required: MANDATORY
+              type: string
+              owner: BPP
+              usage: O1
+              description: Describes the order ID.
+            status:
+              required: MANDATORY
+              type: string
+              owner: BPP
+              usage: ACTIVE
+              description: Describes the order status.
+            provider: *ref_57
+            items: *ref_70
+            quote: *ref_62
+            payments: *ref_71
+            billing: *ref_65
+            fulfillments: *ref_66
+            updated_at: &ref_73
+              required: MANDATORY
+              type: string
+              owner: BPP
+              usage: 2023-12-20T05:28:04.413Z
+              description: Describes the order updated at value.
+      status:
+        context:
+          location: *ref_41
+          domain: *ref_42
+          timestamp: *ref_43
+          bap_id: *ref_44
+          transaction_id: *ref_45
+          message_id: *ref_46
+          version: *ref_47
+          action:
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: status
+            description: >-
+              Describes the Beckn protocol method being called by the sender and
+              executed at the receiver.
+          bap_uri: *ref_49
+          bpp_uri: *ref_51
+          bpp_id: *ref_52
+          ttl: *ref_50
+        message:
+          order_id: *ref_72
+      on_status:
+        context:
+          location: *ref_41
+          domain: *ref_42
+          timestamp: *ref_43
+          bap_id: *ref_44
+          transaction_id: *ref_45
+          message_id: *ref_46
+          version: *ref_47
+          action:
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: on_status
+            description: >-
+              Describes the Beckn protocol method being called by the sender and
+              executed at the receiver.
+          bap_uri: *ref_49
+          bpp_uri: &ref_74
+            required: MANDATORY
+            type: string
+            owner: BPP
+            usage: https://ondc.hotelbpp.com/
+            description: Describes subscriber URL of the BPP for accepting calls from BAPs.
+          bpp_id: *ref_52
+          ttl: *ref_50
+        message:
+          order:
+            id: *ref_72
+            status: &ref_75
+              required: MANDATORY
+              type: string
+              owner: BPP
+              usage: COMPLETED
+              description: Describes the order status.
+            provider: *ref_57
+            items: *ref_70
+            quote: *ref_62
+            payments: *ref_71
+            billing: *ref_65
+            fulfillments: *ref_66
+            updated_at: *ref_73
+            documents: &ref_83
+              descriptor:
+                code:
+                  required: MANDATORY
+                  type: string
+                  owner: BPP
+                  usage: BOOKING_CONFIRMATION
+                  description: Describes the order documents code.
+              url:
+                required: MANDATORY
+                type: string
+                owner: BPP
+                usage: https://confirmation-O1.ondc.hotelbpp.com
+                description: Describes the URL of the document
+      update:
+        context:
+          location: *ref_41
+          domain: *ref_42
+          timestamp: *ref_43
+          bap_id: *ref_44
+          transaction_id: *ref_45
+          message_id: *ref_46
+          version: *ref_47
+          action:
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: update
+            description: >-
+              Describes the Beckn protocol method being called by the sender and
+              executed at the receiver.
+          bap_uri: *ref_49
+          bpp_uri: *ref_51
+          bpp_id: *ref_52
+          ttl: *ref_50
+        message:
+          update_target:
+            required: MANDATORY
+            type: string
+            owner: BPP
+            usage: fulfillment
+            description: Describes the entity which will be updated.
+          order:
+            billing:
+              address:
+                required: OPTIONAL
+                type: string
+                owner: BAP
+                usage: Dwarka, Delhi-110076
+                description: Describes the billing address.
+            id: *ref_72
+      on_update:
+        context:
+          location: *ref_41
+          domain: *ref_42
+          timestamp: *ref_43
+          bap_id: *ref_44
+          transaction_id: *ref_45
+          message_id: *ref_46
+          version: *ref_47
+          action:
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: on_update
+            description: >-
+              Describes the Beckn protocol method being called by the sender and
+              executed at the receiver.
+          bap_uri: *ref_49
+          bpp_uri: *ref_74
+          bpp_id: *ref_52
+          ttl: *ref_50
+        message:
+          order:
+            id: *ref_72
+            status: *ref_75
+            provider: *ref_57
+            items: *ref_70
+            quote: *ref_62
+            payments: *ref_71
+            billing:
+              name: *ref_76
+              address:
+                required: MANDATORY
+                type: string
+                owner: BAP
+                usage: Dwarka, Delhi-110076
+                description: Describes the billing address.
+              state: *ref_77
+              city: *ref_78
+              organization: *ref_79
+              email: *ref_80
+              phone: *ref_81
+              tax_id: *ref_82
+            fulfillments: *ref_66
+            updated_at: *ref_73
+            documents: *ref_83
+      cancel:
+        context:
+          location: *ref_41
+          domain: *ref_42
+          timestamp: *ref_43
+          bap_id: *ref_44
+          transaction_id: *ref_45
+          message_id: *ref_46
+          version: *ref_47
+          action:
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: cancel
+            description: >-
+              Describes the Beckn protocol method being called by the sender and
+              executed at the receiver.
+          bap_uri: *ref_49
+          bpp_uri: *ref_51
+          bpp_id: *ref_52
+          ttl: *ref_50
+        message:
+          order_id: *ref_72
+          cancellation_reason_id:
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: 1
+            description: Describes the cancellation reason id.
+          descriptor: &ref_84
+            short_desc:
+              required: OPTIONAL
+              type: string
+              owner: BAP
+              usage: No more required
+              description: Describes the short description.
+            long_desc:
+              required: OPTIONAL
+              type: string
+              owner: BAP
+              usage: Hotel available at lower price
+              description: Describes the long description.
+      on_cancel:
+        context:
+          location: *ref_41
+          domain: *ref_42
+          timestamp: *ref_43
+          bap_id: *ref_44
+          transaction_id: *ref_45
+          message_id: *ref_46
+          version: *ref_47
+          action:
+            required: MANDATORY
+            type: string
+            owner: BAP
+            usage: on_cancel
+            description: >-
+              Describes the Beckn protocol method being called by the sender and
+              executed at the receiver.
+          bap_uri: *ref_49
+          bpp_uri: *ref_51
+          bpp_id: *ref_52
+          ttl: *ref_50
+        message:
+          order:
+            id: *ref_72
+            status:
+              required: MANDATORY
+              type: string
+              owner: BPP
+              usage: CANCELLED
+              description: Describes the order status.
+            cancellation:
+              cancelled_by:
+                required: MANDATORY
+                type: string
+                owner: BPP
+                usage: CONSUMER
+                description: Describes the order cancelled by entity.
+              reason:
+                id:
+                  required: MANDATORY
+                  type: string
+                  owner: BAP
+                  usage: 1
+                  description: Describes the order cancellation reason id.
+                descriptor: *ref_84
+            updated_at: *ref_73
+x-sandboxui:
+  dropdown:
+    - environment-name: staging
+      link: https://mobility-staging.ondc.org
+x-errorcodes:
+  code:
+    - Event: Route Serviceability error
+      Description: To & from location not serviceable by Seller application
+      From: BPP
+      code: 90201
+    - Event: Tracking not enabled
+      Description: Tracking not enabled for any fulfillment in the order
+      From: BPP
+      code: 90202
+
+x-validations:
+  _TESTS_:
+    search:
+      - _NAME_: SEARCH_CONTEXT
+        action:
+          - search
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_:
+          - _NAME_: CONTEXT_REQUIRED
+            _RETURN_:
+              - _NAME_: REQUIRED_CONTEXT_LOCATION_COUNTRY_CODE
+                attr: $.context.location.country.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_LOCATION_CITY_CODE
+                attr: $.context.location.city.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_DOMAIN
+                attr: $.context.domain
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TIMESTAMP
+                attr: $.context.timestamp
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_ID
+                attr: $.context.bap_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_URI
+                attr: $.context.bap_uri
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TRANSACTION_ID
+                attr: $.context.transaction_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_MESSAGE_ID
+                attr: $.context.message_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_VERSION
+                attr: $.context.version
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TTL
+                attr: $.context.ttl
+                _RETURN_: attr are present
+
+          - _NAME_: CONTEXT_ENUM
+            _RETURN_:
+              - _NAME_: VALID_CONTEXT_LOCATION_COUNTRY_CODE
+                attr: $.context.location.country.code
+                enumList:
+                  - IND
+                _RETURN_: attr any in enumList
+              - _NAME_: VALID_CONTEXT_DOMAIN
+                attr: $.context.domain
+                enumList:
+                  - ONDC:TRV13
+                _RETURN_: attr all in enumList
+
+      - _NAME_: SEARCH_INTENT
+        action:
+          - search
+        _RETURN_:
+          - _NAME_: REQUIRED_CATEGORY_CODE
+            attr: $.message.intent.category.descriptor.code
+            _RETURN_: attr are present
+          - _NAME_: VALID_ENUM_CATEGORY_CODE
+            attr: $.message.intent.category.descriptor.code
+            enumList:
+              - HOTEL
+            _RETURN_: attr all in enumList
+
+      - _NAME_: SEARCH_INTENT_TAGS
+        action:
+          - search
+        _RETURN_:
+          - _NAME_: TAG_GROUPS_REQUIRED
+            tagPath: $.message.intent.tags[*].descriptor.code
+            validTags:
+              - BAP_TERMS
+              - BUYER_FINDER_FEES
+              - CATALOG_INC
+            _RETURN_: tagPath all in validTags
+
+          - _NAME_: TAG_BAP_TERMS
+            _SCOPE_: $.message.intent.tags[?(@.descriptor.code=='BAP_TERMS')]
+            subTags: $.list[*].descriptor.code
+            validValues:
+              - STATIC_TERMS
+              - STATIC_TERMS_NEW
+              - EFFECTIVE_DATE
+            _RETURN_: subTags all in validValues
+
+          - _NAME_: TAG_BUYER_FINDER_FEES
+            _SCOPE_: $.message.intent.tags[?(@.descriptor.code=='BUYER_FINDER_FEES')]
+            subTags: $.list[*].descriptor.code
+            validValues:
+              - BUYER_FINDER_FEES_PERCENTAGE
+            _RETURN_: subTags all in validValues
+
+    on_search:
+      - _NAME_: ON_SEARCH_CONTEXT
+        action:
+          - on_search
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_:
+          - _NAME_: CONTEXT_REQUIRED
+            _RETURN_:
+              - _NAME_: REQUIRED_CONTEXT_LOCATION_COUNTRY_CODE
+                attr: $.context.location.country.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_LOCATION_CITY_CODE
+                attr: $.context.location.city.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_DOMAIN
+                attr: $.context.domain
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TIMESTAMP
+                attr: $.context.timestamp
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_ID
+                attr: $.context.bap_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_URI
+                attr: $.context.bap_uri
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BPP_ID
+                attr: $.context.bpp_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BPP_URI
+                attr: $.context.bpp_uri
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TRANSACTION_ID
+                attr: $.context.transaction_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_MESSAGE_ID
+                attr: $.context.message_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_VERSION
+                attr: $.context.version
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TTL
+                attr: $.context.ttl
+                _RETURN_: attr are present
+
+          - _NAME_: CONTEXT_ENUM
+            _RETURN_:
+              - _NAME_: VALID_CONTEXT_LOCATION_COUNTRY_CODE
+                attr: $.context.location.country.code
+                enumList:
+                  - IND
+                _RETURN_: attr any in enumList
+              - _NAME_: VALID_CONTEXT_DOMAIN
+                attr: $.context.domain
+                enumList:
+                  - ONDC:TRV13
+                _RETURN_: attr all in enumList
+          - _NAME_: REQUIRED_CATALOG_NAME
+            attr: $.message.catalog.descriptor.name
+            _CONTINUE_: "!(attr are present)"
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CATALOG_CODE
+            attr: $.message.catalog.descriptor.code
+            _CONTINUE_: "!(attr are present)"
+            _RETURN_: attr are present
+
+      - _NAME_: PROVIDERS_REQUIRED
+        action:
+          - on_search
+        _RETURN_:
+          - _NAME_: REQUIRED_PROVIDER_ID
+            attr: $.message.catalog.providers[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_PROVIDER_NAME
+            attr: $.message.catalog.providers[*].descriptor.name
+            _CONTINUE_: "!(attr are present)" 
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_PROVIDER_IMAGES
+            attr: $.message.catalog.providers[*].descriptor.images[*].url
+            reg: ["^https:\/\/.*"]
+            _CONTINUE_: "!(attr are present)"
+            _RETURN_: attr follow regex reg
+          - _NAME_: REQUIRED_PROVIDER_LOCATIONS
+            attr: $.message.catalog.providers[*].locations[*].id
+            _CONTINUE_: "!(attr are present)"
+            _RETURN_: attr are present
+          # - _NAME_: REQUIRED_PROVIDER_LOCATIONS_GPS
+          #   attr: $.message.catalog.providers[*].locations[*].gps
+          #   reg: ["^-?\d+(\.\d+)?\s*,\s*-?\d+(\.\d+)?$"]
+          #   _RETURN_: attr follow regex reg
+
+      - _NAME_: PROVIDER_PAYMENTS
+        action:
+          - on_search
+        _RETURN_:
+          - _NAME_: VALID_PAYMENT_TYPES
+            enumPath: $.message.catalog.providers[*].payments[*].type
+            enumList:
+              - PRE-ORDER
+              - ON-FULFILLMENT
+              - PART-PAYMENT
+            _CONTINUE_: "!(enumPath are present)"
+            _RETURN_: enumPath all in enumList
+
+      - _NAME_: PROVIDER_ITEMS
+        action:
+          - on_search
+        _RETURN_:
+          - _NAME_: REQUIRED_ITEM_ID
+            attr: $.message.catalog.providers[*].items[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ITEM_LABEL
+            attr: $.message.catalog.providers[*].items[*].time.label
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ITEM_TIMESTAMPS
+            attr: $.message.catalog.providers[*].items[*].time.timestamp
+            _RETURN_: attr are present    
+          - _NAME_: REQUIRED_ITEM_NAME
+            attr: $.message.catalog.providers[*].items[*].descriptor.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ITEM_CODE
+            attr: $.message.catalog.providers[*].items[*].descriptor.code
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ITEM_IMAGES
+            attr: $.message.catalog.providers[*].items[*].descriptor.images[*].url
+            reg: ["^https:\/\/.*"]
+            _CONTINUE_: "!(attr are present)"
+            _RETURN_: attr follow regex reg
+          - _NAME_: REQUIRED_ITEM_PRICE
+            attr: $.message.catalog.providers[*].items[*].price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ITEM_PRICE_CURRENCY
+            attr: $.message.catalog.providers[*].items[*].price.currency
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_ITEM_PRICE_MAX_VALUE
+            attr: $.message.catalog.providers[*].items[*].price.maximum_value
+            _RETURN_: attr are present    
+          - _NAME_: REQUIRED_ITEM_QUANTITY_AVAILABLE
+            attr: $.message.catalog.providers[*].items[*].quantity.available.count
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ITEM_QUANTITY_MAXIMUM_COUNT
+            attr: $.message.catalog.providers[*].items[*].quantity.maximum.count
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_ITEM_LOCATION_LINK
+            attr: $.message.catalog.providers[*].items[*].location_ids[*]
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ITEM_CATEGORY_LINK
+            attr: $.message.catalog.providers[*].items[*].category_ids[*]
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ITEM_PAYMENT_LINK
+            attr: $.message.catalog.providers[*].items[*].payment_ids[*]
+            _RETURN_: attr are present
+
+      - _NAME_: ITEM_ADDONS
+        action:
+          - on_search
+        _RETURN_:
+          - _NAME_: REQUIRED_ADDON_ID
+            attr: $.message.catalog.providers[*].items[*].add_ons[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ADDON_NAME
+            attr: $.message.catalog.providers[*].items[*].add_ons[*].descriptor.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ADDON_PRICE
+            attr: $.message.catalog.providers[*].items[*].add_ons[*].price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ADDON_PRICE_CURRENCY
+            attr: $.message.catalog.providers[*].items[*].add_ons[*].price.currency
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_ADDON_PRICE_MAXIMUM_VALUE
+            attr: $.message.catalog.providers[*].items[*].add_ons[*].price.maximum_value
+            _RETURN_: attr are present    
+          - _NAME_: REQUIRED_CANCELLATION_TERMS_URL
+            attr: $.message.catalog.providers[*].items[*].cancellation_terms[*].external_ref.url
+            reg: ["^https:\/\/.*"]
+            _CONTINUE_: "!(attr are present)"
+            _RETURN_: attr follow regex reg
+
+    select:
+      - _NAME_: SELECT_CONTEXT
+        action:
+          - select
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_:
+          - _NAME_: REQUIRED_CONTEXT_FIELDS
+            _RETURN_:
+              - _NAME_: REQUIRED_CONTEXT_DOMAIN
+                attr: $.context.domain
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_COUNTRY
+                attr: $.context.location.country.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_CITY
+                attr: $.context.location.city.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TRANSACTION_ID
+                attr: $.context.transaction_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_MESSAGE_ID
+                attr: $.context.message_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_ACTION
+                attr: $.context.action
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TIMESTAMP
+                attr: $.context.timestamp
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_VERSION
+                attr: $.context.version
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_URI
+                attr: $.context.bap_uri
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_ID
+                attr: $.context.bap_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BPP_URI
+                attr: $.context.bpp_uri
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BPP_ID
+                attr: $.context.bpp_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TTL
+                attr: $.context.ttl
+                _RETURN_: attr are present
+
+          - _NAME_: CONTEXT_ENUM_VALIDATION
+            _RETURN_:
+              - _NAME_: VALID_CONTEXT_COUNTRY_CODE
+                attr: $.context.location.country.code
+                enumList:
+                  - IND
+                _RETURN_: attr any in enumList
+              - _NAME_: VALID_CONTEXT_DOMAIN
+                attr: $.context.domain
+                enumList:
+                  - ONDC:TRV13
+                _RETURN_: attr any in enumList
+
+      - _NAME_: SELECT_ORDER
+        action:
+          - select
+        _RETURN_:
+          - _NAME_: REQUIRED_PROVIDER_ID
+            attr: $.message.order.provider.id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_PROVIDER_TIME_LABEL
+            attr: $.message.order.provider.time.label
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_PROVIDER_TIME_RANGE
+            attr: $.message.order.provider.time.range.start
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_PROVIDER_TIME_RANGE_END
+            attr: $.message.order.provider.time.range.end
+            _RETURN_: attr are present
+
+      - _NAME_: SELECT_ORDER_ITEMS
+        action:
+          - select
+        _RETURN_:
+          - _NAME_: REQUIRED_ITEM_ID
+            attr: $.message.order.items[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ITEM_LOCATION
+            attr: $.message.order.items[*].location_ids[*]
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ITEM_QUANTITY_SELECTED
+            attr: $.message.order.items[*].quantity.selected.count
+            _RETURN_: attr are present
+          - _NAME_: ITEM_ADDON_VALIDATION
+            attr: $.message.order.items[*].add_ons
+            _CONTINUE_: "!(attr are present)"
+            _RETURN_:
+              - _NAME_: REQUIRED_ITEM_ADDON_ID
+                attr: $.message.order.items[*].add_ons[*].id
+                _RETURN_: attr are present
+
+      - _NAME_: SELECT_ORDER_FULFILLMENTS
+        action:
+          - select
+        _RETURN_:
+          - _NAME_: REQUIRED_FULFILLMENT_TAGS
+            attr: $.message.order.fulfillments[*].tags[*].descriptor.code
+            _RETURN_: attr are present
+          - _NAME_: VALID_FULFILLMENT_TAG_GUESTS
+            attr: $.message.order.fulfillments[*].tags[*].descriptor.code
+            enumList:
+              - GUESTS
+            _RETURN_: attr all in enumList
+          - _NAME_: VALID_FULFILLMENT_SUBTAGS
+            attr: $.message.order.fulfillments[*].tags[*].list[*].descriptor.code
+            enumList:
+              - ADULTS
+              - CHILDREN
+            _RETURN_: attr all in enumList
+
+    on_select:
+      - _NAME_: ON_SELECT_CONTEXT
+        action:
+          - on_select
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_:
+          - _NAME_: REQUIRED_CONTEXT_FIELDS
+            _RETURN_:
+              - _NAME_: REQUIRED_CONTEXT_DOMAIN
+                attr: $.context.domain
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_COUNTRY
+                attr: $.context.location.country.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_CITY
+                attr: $.context.location.city.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TRANSACTION_ID
+                attr: $.context.transaction_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_MESSAGE_ID
+                attr: $.context.message_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_ACTION
+                attr: $.context.action
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TIMESTAMP
+                attr: $.context.timestamp
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_VERSION
+                attr: $.context.version
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_URI
+                attr: $.context.bap_uri
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_ID
+                attr: $.context.bap_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BPP_URI
+                attr: $.context.bpp_uri
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BPP_ID
+                attr: $.context.bpp_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TTL
+                attr: $.context.ttl
+                _RETURN_: attr are present
+
+          - _NAME_: CONTEXT_ENUM_VALIDATION
+            _RETURN_:
+              - _NAME_: VALID_CONTEXT_COUNTRY_CODE
+                attr: $.context.location.country.code
+                enumList:
+                  - IND
+                _RETURN_: attr any in enumList
+              - _NAME_: VALID_CONTEXT_DOMAIN
+                attr: $.context.domain
+                enumList:
+                  - ONDC:TRV13
+                _RETURN_: attr any in enumList
+
+      - _NAME_: ON_SELECT_ORDER
+        action:
+          - on_select
+        _RETURN_:
+          - _NAME_: REQUIRED_PROVIDER_ID
+            attr: $.message.order.provider.id
+            _RETURN_: attr are present
+
+      - _NAME_: ON_SELECT_ORDER_ITEMS
+        action:
+          - on_select
+        _RETURN_:
+          - _NAME_: REQUIRED_ITEM_ID
+            attr: $.message.order.items[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ITEM_ADDS_ON_IDS
+            attr: $.message.order.items[*].add_ons[*].id
+            _RETURN_: attr are present
+
+      - _NAME_: ON_SELECT_ORDER_QUOTE
+        action:
+          - on_select
+        _RETURN_:
+          - _NAME_: REQUIRED_QUOTE_PRICE
+            attr: $.message.order.quote.price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_CURRENCY
+            attr: $.message.order.quote.price.currency
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_BREAKUP
+            attr: $.message.order.quote.breakup[*].price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_BREAKUP_PRICE_CURRENCY
+            attr: $.message.order.quote.breakup[*].price.currency
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_QUOTE_BREAKUP_TITLE
+            attr: $.message.order.quote.breakup[*].title
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_QUOTE_TTL
+            attr: $.message.order.quote.ttl
+            _RETURN_: attr are present
+
+      - _NAME_: ON_SELECT_ORDER_PAYMENTS
+        action:
+          - on_select
+        _RETURN_:
+          - _NAME_: REQUIRED_PAYMENT_ID
+            attr: $.message.order.payments[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_PAYMENT_TYPE
+            attr: $.message.order.payments[*].type
+            _RETURN_: attr are present
+          - _NAME_: VALID_PAYMENT_TYPES
+            attr: $.message.order.payments[*].type
+            enumList:
+              - PRE-ORDER
+              - ON-FULFILLMENT
+              - PART-PAYMENT
+            _RETURN_: attr all in enumList
+
+    init:
+      - _NAME_: INIT_CONTEXT
+        action:
+          - init
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_:
+          - _NAME_: REQUIRED_CONTEXT_FIELDS
+            _RETURN_:
+              - _NAME_: REQUIRED_CONTEXT_DOMAIN
+                attr: $.context.domain
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_COUNTRY
+                attr: $.context.location.country.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_CITY
+                attr: $.context.location.city.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TRANSACTION_ID
+                attr: $.context.transaction_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_MESSAGE_ID
+                attr: $.context.message_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_ACTION
+                attr: $.context.action
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TIMESTAMP
+                attr: $.context.timestamp
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_VERSION
+                attr: $.context.version
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_URI
+                attr: $.context.bap_uri
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_ID
+                attr: $.context.bap_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BPP_URI
+                attr: $.context.bpp_uri
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BPP_ID
+                attr: $.context.bpp_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TTL
+                attr: $.context.ttl
+                _RETURN_: attr are present
+
+          - _NAME_: CONTEXT_ENUM_VALIDATION
+            _RETURN_:
+              - _NAME_: VALID_CONTEXT_COUNTRY_CODE
+                attr: $.context.location.country.code
+                enumList:
+                  - IND
+                _RETURN_: attr any in enumList
+              - _NAME_: VALID_CONTEXT_DOMAIN
+                attr: $.context.domain
+                enumList:
+                  - ONDC:TRV13
+                _RETURN_: attr any in enumList
+
+      - _NAME_: INIT_ORDER_PROVIDER
+        action:
+          - init
+        _RETURN_:
+          - _NAME_: REQUIRED_PROVIDER_ID
+            attr: $.message.order.provider.id
+            _RETURN_: attr are present
+
+      - _NAME_: INIT_ORDER_ITEMS
+        action:
+          - init
+        _RETURN_:
+          - _NAME_: REQUIRED_ITEM_ID
+            attr: $.message.order.items[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ITEM_LOCATION_IDS
+            attr: $.message.order.items[*].location_ids[*]
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ITEM_QUANTITY
+            attr: $.message.order.items[*].quantity.selected.count
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_ADDS_ON_IDS
+            attr: $.message.order.items[*].add_ons[*].id
+            _RETURN_: attr are present  
+
+      - _NAME_: INIT_ORDER_PAYMENTS
+        action:
+          - init
+        _RETURN_:
+          - _NAME_: REQUIRED_PAYMENT_ID
+            attr: $.message.order.payments[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_PAYMENT_TYPE
+            attr: $.message.order.payments[*].type
+            _RETURN_: attr are present
+          - _NAME_: VALID_PAYMENT_TYPES
+            attr: $.message.order.payments[*].type
+            enumList:
+              - PRE-ORDER
+              - ON-FULFILLMENT
+              - PART-PAYMENT
+            _RETURN_: attr all in enumList
+          - _NAME_: REQUIRED_PAYMENT_PARAMS
+            attr: $.message.order.payments[*].params.amount
+            _RETURN_: attr are present
+
+      - _NAME_: INIT_ORDER_BILLING
+        action:
+          - init
+        _RETURN_:
+          - _NAME_: REQUIRED_BILLING_NAME
+            attr: $.message.order.billing.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_ADDRESS
+            attr: $.message.order.billing.address
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_STATE_NAME
+            attr: $.message.order.billing.state.name
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_BILLING_CITY_NAME
+            attr: $.message.order.billing.city.name
+            _RETURN_: attr are present   
+          - _NAME_: REQUIRED_BILLING_ORGANIZATION_DESCRIPTOR_NAME
+            attr: $.message.order.billing.organization.descriptor.name
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_BILLING_ORGANIZATION_ADDRESS
+            attr: $.message.order.billing.organization.address
+            _RETURN_: attr are present      
+          - _NAME_: REQUIRED_BILLING_EMAIL
+            attr: $.message.order.billing.email
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_PHONE
+            attr: $.message.order.billing.phone
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_TAX_ID
+            attr: $.message.order.billing.tax_id
+            _RETURN_: attr are present
+
+      - _NAME_: INIT_ORDER_FULFILLMENTS
+        action:
+          - init
+        _RETURN_:
+          - _NAME_: REQUIRED_FULFILLMENT_ID
+            attr: $.message.order.fulfillments[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_NAME
+            attr: $.message.order.fulfillments[*].customer.person.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_AGE
+            attr: $.message.order.fulfillments[*].customer.person.age
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_DOB
+            attr: $.message.order.fulfillments[*].customer.person.dob
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_CUSTOMER_GENDER
+            attr: $.message.order.fulfillments[*].customer.person.gender
+            _RETURN_: attr are present     
+          - _NAME_: REQUIRED_CUSTOMER_CONTACT
+            attr: $.message.order.fulfillments[*].customer.contact.phone
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_CONTACT_EMAIL
+            attr: $.message.order.fulfillments[*].customer.contact.email
+            _RETURN_: attr are present  
+
+      - _NAME_: INIT_ORDER_TAGS
+        action:
+          - init
+        _RETURN_:
+          - _NAME_: REQUIRED_BAP_TERMS
+            attr: $.message.order.tags[?(@.descriptor.code=='BAP_TERMS')].list[*].descriptor.code
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BUYER_FINDER_FEES
+            attr: $.message.order.tags[?(@.descriptor.code=='BUYER_FINDER_FEES')].list[*].descriptor.code
+            _RETURN_: attr are present
+
+    on_init:
+      - _NAME_: ON_INIT_CONTEXT
+        action:
+          - on_init
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_:
+          - _NAME_: REQUIRED_CONTEXT_FIELDS
+            _RETURN_:
+              - _NAME_: REQUIRED_CONTEXT_DOMAIN
+                attr: $.context.domain
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_COUNTRY
+                attr: $.context.location.country.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_CITY
+                attr: $.context.location.city.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TRANSACTION_ID
+                attr: $.context.transaction_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_MESSAGE_ID
+                attr: $.context.message_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_ACTION
+                attr: $.context.action
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TIMESTAMP
+                attr: $.context.timestamp
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_VERSION
+                attr: $.context.version
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_URI
+                attr: $.context.bap_uri
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_ID
+                attr: $.context.bap_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BPP_URI
+                attr: $.context.bpp_uri
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BPP_ID
+                attr: $.context.bpp_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TTL
+                attr: $.context.ttl
+                _RETURN_: attr are present
+
+          - _NAME_: CONTEXT_ENUM_VALIDATION
+            _RETURN_:
+              - _NAME_: VALID_CONTEXT_COUNTRY_CODE
+                attr: $.context.location.country.code
+                enumList:
+                  - IND
+                _RETURN_: attr any in enumList
+              - _NAME_: VALID_CONTEXT_DOMAIN
+                attr: $.context.domain
+                enumList:
+                  - ONDC:TRV13
+                _RETURN_: attr any in enumList
+
+      - _NAME_: ON_INIT_ORDER_PROVIDER
+        action:
+          - on_init
+        _RETURN_:
+          - _NAME_: REQUIRED_PROVIDER_ID
+            attr: $.message.order.provider.id
+            _RETURN_: attr are present          
+
+      - _NAME_: ON_INIT_ITEMS
+        action:
+          - on_init
+        _RETURN_:
+          - _NAME_: REQUIRED_ITEMS
+            _RETURN_:
+              - _NAME_: REQUIRED_MESSAGE_ITEMS_ID
+                attr: $.message.order.items[*].id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_MESSAGE_ITEMS_ADD_ONS
+                attr: $.message.order.items[*].add_ons[*].id
+                _RETURN_: attr are present  
+              - _NAME_: REQUIRED_ITEMS_LOCATIONS
+                attr: $.message.order.items[*].location_ids[*]
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ITEMS_QUANTITY
+                attr: $.message.order.items[*].quantity.selected.count
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ITEMS_ADDONS
+                attr: $.message.order.items[*].add_ons[*].id
+                _RETURN_: attr are present
+
+      - _NAME_: ON_INIT_ORDER_QUOTE
+        action:
+          - on_init
+        _RETURN_:
+          - _NAME_: REQUIRED_QUOTE_PRICE
+            attr: $.message.order.quote.price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_CURRENCY
+            attr: $.message.order.quote.price.currency
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_BREAKUP
+            attr: $.message.order.quote.breakup[*].price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_BREAKUP_PRICE_CURRENCY
+            attr: $.message.order.quote.breakup[*].price.currency
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_QUOTE_BREAKUP_TITLE
+            attr: $.message.order.quote.breakup[*].title
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_QUOTE_TTL
+            attr: $.message.order.quote.ttl
+            _RETURN_: attr are present
+
+      - _NAME_: ON_INIT_PAYMENTS
+        action:
+          - on_init
+        _RETURN_:
+          - _NAME_: REQUIRED_PAYMENT_ID
+            attr: $.message.order.payments[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_PAYMENT_TYPE
+            attr: $.message.order.payments[*].type
+            _RETURN_: attr are present
+          - _NAME_: VALID_PAYMENT_TYPES
+            attr: $.message.order.payments[*].type
+            enumList:
+              - PRE-ORDER
+              - ON-FULFILLMENT
+              - PART-PAYMENT
+            _RETURN_: attr all in enumList  
+          - _NAME_: REQUIRED_PAYMENT_STATUS
+            attr: $.message.order.payments[*].status
+            _RETURN_: attr are present
+          - _NAME_: VALID_PAYMENT_STATUS
+            attr: $.message.order.payments[*].status
+            enumList:
+              - PAID
+              - NOT-PAID
+            _RETURN_: attr all in enumList  
+          # - _NAME_: REQUIRED_PAYMENT_PARAMS
+          #   attr: $.message.order.payments[*].params.amount
+          #   _RETURN_: attr are present
+
+      - _NAME_: ON_INIT_ORDER_BILLING
+        action:
+          - on_init
+        _RETURN_:
+          - _NAME_: REQUIRED_BILLING_NAME
+            attr: $.message.order.billing.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_ADDRESS
+            attr: $.message.order.billing.address
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_STATE_NAME
+            attr: $.message.order.billing.state.name
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_BILLING_CITY_NAME
+            attr: $.message.order.billing.city.name
+            _RETURN_: attr are present   
+          - _NAME_: REQUIRED_BILLING_ORGANIZATION_DESCRIPTOR_NAME
+            attr: $.message.order.billing.organization.descriptor.name
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_BILLING_ORGANIZATION_ADDRESS
+            attr: $.message.order.billing.organization.address
+            _RETURN_: attr are present      
+          - _NAME_: REQUIRED_BILLING_EMAIL
+            attr: $.message.order.billing.email
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_PHONE
+            attr: $.message.order.billing.phone
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_TAX_ID
+            attr: $.message.order.billing.tax_id
+            _RETURN_: attr are present
+
+      - _NAME_: ON_INIT_ORDER_FULFILLMENTS
+        action:
+          - on_init
+        _RETURN_:
+          - _NAME_: REQUIRED_FULFILLMENT_ID
+            attr: $.message.order.fulfillments[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_NAME
+            attr: $.message.order.fulfillments[*].customer.person.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_AGE
+            attr: $.message.order.fulfillments[*].customer.person.age
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_DOB
+            attr: $.message.order.fulfillments[*].customer.person.dob
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_CUSTOMER_GENDER
+            attr: $.message.order.fulfillments[*].customer.person.gender
+            _RETURN_: attr are present     
+          - _NAME_: REQUIRED_CUSTOMER_CONTACT
+            attr: $.message.order.fulfillments[*].customer.contact.phone
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_CONTACT_EMAIL
+            attr: $.message.order.fulfillments[*].customer.contact.email
+            _RETURN_: attr are present  
+
+      - _NAME_: ON_INIT_TAGS
+        action:
+          - on_init
+        _RETURN_:
+          - _NAME_: REQUIRED_TAG_GROUPS
+            attr: $.message.order.tags[*].descriptor.code
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_TAG_VALUES
+            attr: $.message.order.tags[*].list[*].descriptor.code
+            _RETURN_: attr are present
+          - _NAME_: PAYMENT_TAG_GROUP
+            validTags:
+              - BAP_TERMS
+              - BUYER_FINDER_FEES
+              - BPP_TERMS
+            tagPath: $.message.order.tags[*].descriptor.code
+            _RETURN_: tagPath all in validTags
+          - _NAME_: REQUIRED_PAYMENT_TAG_BPP_TERMS
+            _SCOPE_: $.message.order.tags[?(@.descriptor.code=='BPP_TERMS')]
+            subTags: $.list[*].descriptor.code
+            validValues:
+              - MAX_LIABILITY
+              - MAX_LIABILITY_CAP
+              - MANDATORY_ARBITRATION
+              - COURT_JURISDICTION
+              - DELAY_INTEREST
+              - TAX_NUMBER
+            _CONTINUE_: "!(subTags are present)"
+            _RETURN_: subTags all in validValues
+
+    confirm:
+      - _NAME_: CONFIRM_CONTEXT
+        action:
+          - confirm
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_:
+          - _NAME_: REQUIRED_CONTEXT_FIELDS
+            _RETURN_:
+              - _NAME_: REQUIRED_CONTEXT_DOMAIN
+                attr: $.context.domain
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_COUNTRY
+                attr: $.context.location.country.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_CITY
+                attr: $.context.location.city.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TRANSACTION_ID
+                attr: $.context.transaction_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_MESSAGE_ID
+                attr: $.context.message_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_ACTION
+                attr: $.context.action
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TIMESTAMP
+                attr: $.context.timestamp
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_VERSION
+                attr: $.context.version
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_URI
+                attr: $.context.bap_uri
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BAP_ID
+                attr: $.context.bap_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BPP_URI
+                attr: $.context.bpp_uri
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_BPP_ID
+                attr: $.context.bpp_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TTL
+                attr: $.context.ttl
+                _RETURN_: attr are present
+
+          - _NAME_: CONTEXT_ENUM_VALIDATION
+            _RETURN_:
+              - _NAME_: VALID_CONTEXT_COUNTRY_CODE
+                attr: $.context.location.country.code
+                enumList:
+                  - IND
+                _RETURN_: attr any in enumList
+              - _NAME_: VALID_CONTEXT_DOMAIN
+                attr: $.context.domain
+                enumList:
+                  - ONDC:TRV13
+                _RETURN_: attr any in enumList
+
+      - _NAME_: CONFIRM_ORDER_PROVIDER
+        action:
+          - confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_PROVIDER_ID
+            attr: $.message.order.provider.id
+            _RETURN_: attr are present          
+
+      - _NAME_: CONFIRM_ITEMS
+        action:
+          - confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_ITEMS
+            _RETURN_:
+              - _NAME_: REQUIRED_MESSAGE_ITEMS_ID
+                attr: $.message.order.items[*].id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_MESSAGE_ITEMS_ADD_ONS
+                attr: $.message.order.items[*].add_ons[*].id
+                _RETURN_: attr are present  
+              - _NAME_: REQUIRED_ITEMS_LOCATIONS
+                attr: $.message.order.items[*].location_ids[*]
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ITEMS_QUANTITY
+                attr: $.message.order.items[*].quantity.selected.count
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ITEMS_ADDONS
+                attr: $.message.order.items[*].add_ons[*].id
+                _RETURN_: attr are present
+
+      - _NAME_: CONFIRM_ORDER_QUOTE
+        action:
+          - confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_QUOTE_PRICE
+            attr: $.message.order.quote.price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_CURRENCY
+            attr: $.message.order.quote.price.currency
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_BREAKUP
+            attr: $.message.order.quote.breakup[*].price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_BREAKUP_PRICE_CURRENCY
+            attr: $.message.order.quote.breakup[*].price.currency
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_QUOTE_BREAKUP_TITLE
+            attr: $.message.order.quote.breakup[*].title
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_QUOTE_TTL
+            attr: $.message.order.quote.ttl
+            _RETURN_: attr are present
+
+      - _NAME_: CONFIRM_PAYMENTS
+        action:
+          - confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_PAYMENT_ID
+            attr: $.message.order.payments[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_PAYMENT_TYPE
+            attr: $.message.order.payments[*].type
+            _RETURN_: attr are present
+          - _NAME_: VALID_PAYMENT_TYPES
+            attr: $.message.order.payments[*].type
+            enumList:
+              - PRE-ORDER
+              - ON-FULFILLMENT
+              - PART-PAYMENT
+            _RETURN_: attr all in enumList  
+          - _NAME_: REQUIRED_PAYMENT_STATUS
+            attr: $.message.order.payments[*].status
+            _RETURN_: attr are present
+          - _NAME_: VALID_PAYMENT_STATUS
+            attr: $.message.order.payments[*].status
+            enumList:
+              - PAID
+              - NOT-PAID
+            _RETURN_: attr all in enumList
+          # - _NAME_: REQUIRED_PAYMENT_PARAMS_AMOUNT
+          #   attr: $.message.order.payments[*].params.amount
+          #   _RETURN_: attr are present
+          # - _NAME_: REGEX_PAYMENT_TRANSACTION_ID
+          #   attr: $.message.order.payments[*].params.transaction_id
+          #   reg:
+          #     - ^[a-zA-Z0-9._-]+$
+          #   _RETURN_: attr follow regex reg
+
+      - _NAME_: CONFIRM_ORDER_BILLING
+        action:
+          - confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_BILLING_NAME
+            attr: $.message.order.billing.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_ADDRESS
+            attr: $.message.order.billing.address
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_STATE_NAME
+            attr: $.message.order.billing.state.name
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_BILLING_CITY_NAME
+            attr: $.message.order.billing.city.name
+            _RETURN_: attr are present   
+          - _NAME_: REQUIRED_BILLING_ORGANIZATION_DESCRIPTOR_NAME
+            attr: $.message.order.billing.organization.descriptor.name
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_BILLING_ORGANIZATION_ADDRESS
+            attr: $.message.order.billing.organization.address
+            _RETURN_: attr are present      
+          - _NAME_: REQUIRED_BILLING_EMAIL
+            attr: $.message.order.billing.email
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_PHONE
+            attr: $.message.order.billing.phone
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_TAX_ID
+            attr: $.message.order.billing.tax_id
+            _RETURN_: attr are present
+
+      - _NAME_: CONFIRM_ORDER_FULFILLMENTS
+        action:
+          - confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_FULFILLMENT_ID
+            attr: $.message.order.fulfillments[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_NAME
+            attr: $.message.order.fulfillments[*].customer.person.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_AGE
+            attr: $.message.order.fulfillments[*].customer.person.age
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_DOB
+            attr: $.message.order.fulfillments[*].customer.person.dob
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_CUSTOMER_GENDER
+            attr: $.message.order.fulfillments[*].customer.person.gender
+            _RETURN_: attr are present     
+          - _NAME_: REQUIRED_CUSTOMER_CONTACT
+            attr: $.message.order.fulfillments[*].customer.contact.phone
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_CONTACT_EMAIL
+            attr: $.message.order.fulfillments[*].customer.contact.email
+            _RETURN_: attr are present
+
+      - _NAME_: CONFIRM_TAGS
+        action:
+          - confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_TAG_GROUPS
+            attr: $.message.order.tags[*].descriptor.code
+            _RETURN_: attr are present
+          - _NAME_: PAYMENT_TAG_GROUP
+            validTags:
+              - BAP_TERMS
+              - BUYER_FINDER_FEES
+              - BPP_TERMS
+            tagPath: $.message.order.tags[*].descriptor.code
+            _RETURN_: tagPath all in validTags
+          - _NAME_: REQUIRED_PAYMENT_TAG_BPP_TERMS
+            _SCOPE_: $.message.order.tags[?(@.descriptor.code=='BPP_TERMS')]
+            subTags: $.list[*].descriptor.code
+            validValues:
+              - MAX_LIABILITY
+              - MAX_LIABILITY_CAP
+              - MANDATORY_ARBITRATION
+              - COURT_JURISDICTION
+              - DELAY_INTEREST
+              - TAX_NUMBER
+            _CONTINUE_: "!(subTags are present)"
+            _RETURN_: subTags all in validValues
+
+      - _NAME_: CONFIRM_TIMESTAMPS
+        action:
+          - confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_CREATED_AT
+            attr: $.message.order.created_at
+            reg:
+              - ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$
+            _RETURN_: attr follow regex reg
+          - _NAME_: REQUIRED_UPDATED_AT
+            attr: $.message.order.updated_at
+            reg:
+              - ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$
+            _RETURN_: attr follow regex reg
+
+    on_confirm:
+      - _NAME_: ON_CONFIRM_CONTEXT
+        action:
+          - on_confirm
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_: &ref_30
+          - _NAME_: REQUIRED_ON_CONFIRM_CONTEXT
+            _RETURN_:
+              - _NAME_: REQUIRED_CONTEXT_DOMAIN
+                attr: $.context.domain
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_ACTION
+                attr: $.context.action
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_VERSION
+                attr: $.context.version
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_MESSAGE_ID
+                attr: $.context.message_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TRANSACTION_ID
+                attr: $.context.transaction_id
+                _RETURN_: attr are present
+              - _NAME_: REGEX_CONTEXT_TIMESTAMP
+                attr: $.context.timestamp
+                reg:
+                  - ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$
+                _RETURN_: attr follow regex reg          
+
+      - _NAME_: ON_CONFIRM_ORDER
+        action:
+          - on_confirm
+        _RETURN_: &ref_42
+          - _NAME_: REQUIRED_ON_CONFIRM_ORDER
+            _RETURN_:
+              - _NAME_: REQUIRED_ORDER_ID
+                attr: $.message.order.id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ORDER_STATUS
+                attr: $.message.order.status
+                _RETURN_: attr are present
+              - _NAME_: VALID_ORDER_STATUS
+                attr: $.message.order.status
+                enumList:
+                  - SOFT-CANCEL
+                  - CONFIRM-CANCEL
+                  - SOFT-UPDATE
+                  - CONFIRM-UPDATE
+                  - ACTIVE
+                  - COMPLETE
+                  - CANCELLED
+                _RETURN_: attr all in enumList   
+              - _NAME_: REQUIRED_ON_CONFIRM_UPDATED_AT
+                attr: $.message.order.updated_at
+                _RETURN_: attr are present
+
+          - _NAME_: VALID_ENUM_ON_CONFIRM_ORDER
+            _RETURN_:
+              - _NAME_: VALID_ENUM_ORDER_STATUS
+                attr: $.message.order.status
+                enumList:
+                  - SOFT_CANCEL
+                  - CONFIRM_CANCEL
+                  - ACTIVE
+                  - COMPLETE
+                  - CANCELLED
+                _RETURN_: attr any in enumList
+              - _NAME_: REGEX_ON_CONFIRM_UPDATED_AT
+                attr: $.message.order.updated_at
+                reg: ['^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$']
+                _RETURN_: attr follow regex reg
+
+      - _NAME_: ON_CONFIRM_ITEMS
+        action:
+          - on_confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_ITEMS
+            _RETURN_:
+              - _NAME_: REQUIRED_MESSAGE_ITEMS_ID
+                attr: $.message.order.items[*].id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_MESSAGE_ITEMS_ADD_ONS
+                attr: $.message.order.items[*].add_ons[*].id
+                _RETURN_: attr are present  
+              - _NAME_: REQUIRED_ITEMS_LOCATIONS
+                attr: $.message.order.items[*].location_ids[*]
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ITEMS_QUANTITY
+                attr: $.message.order.items[*].quantity.selected.count
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ITEMS_ADDONS
+                attr: $.message.order.items[*].add_ons[*].id
+                _RETURN_: attr are present
+
+      - _NAME_: ON_CONFIRM_ORDER_FULFILLMENTS
+        action:
+          - on_confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_FULFILLMENT_ID
+            attr: $.message.order.fulfillments[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_NAME
+            attr: $.message.order.fulfillments[*].customer.person.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_AGE
+            attr: $.message.order.fulfillments[*].customer.person.age
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_DOB
+            attr: $.message.order.fulfillments[*].customer.person.dob
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_CUSTOMER_GENDER
+            attr: $.message.order.fulfillments[*].customer.person.gender
+            _RETURN_: attr are present     
+          - _NAME_: REQUIRED_CUSTOMER_CONTACT
+            attr: $.message.order.fulfillments[*].customer.contact.phone
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_CONTACT_EMAIL
+            attr: $.message.order.fulfillments[*].customer.contact.email
+            _RETURN_: attr are present
+
+      - _NAME_: ON_CONFIRM_PROVIDER
+        action:
+          - on_confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_PROVIDER_ID
+            attr: $.message.order.provider.id
+            _RETURN_: attr are present
+
+      - _NAME_: ON_CONFIRM_ORDER_QUOTE
+        action:
+          - on_confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_QUOTE_PRICE
+            attr: $.message.order.quote.price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_CURRENCY
+            attr: $.message.order.quote.price.currency
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_BREAKUP
+            attr: $.message.order.quote.breakup[*].price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_BREAKUP_PRICE_CURRENCY
+            attr: $.message.order.quote.breakup[*].price.currency
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_QUOTE_BREAKUP_TITLE
+            attr: $.message.order.quote.breakup[*].title
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_QUOTE_TTL
+            attr: $.message.order.quote.ttl
+            _RETURN_: attr are present
+
+      - _NAME_: ON_CONFIRM_PAYMENTS
+        action:
+          - on_confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_PAYMENT_ID
+            attr: $.message.order.payments[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_PAYMENT_TYPE
+            attr: $.message.order.payments[*].type
+            _RETURN_: attr are present
+          - _NAME_: VALID_PAYMENT_TYPES
+            attr: $.message.order.payments[*].type
+            enumList:
+              - PRE-ORDER
+              - ON-FULFILLMENT
+              - PART-PAYMENT
+            _RETURN_: attr all in enumList  
+          - _NAME_: REQUIRED_PAYMENT_STATUS
+            attr: $.message.order.payments[*].status
+            _RETURN_: attr are present
+          - _NAME_: VALID_PAYMENT_STATUS
+            attr: $.message.order.payments[*].status
+            enumList:
+              - PAID
+              - NOT-PAID
+            _RETURN_: attr all in enumList
+
+      - _NAME_: ON_CONFIRM_ORDER_BILLING
+        action:
+          - on_confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_BILLING_NAME
+            attr: $.message.order.billing.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_ADDRESS
+            attr: $.message.order.billing.address
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_STATE_NAME
+            attr: $.message.order.billing.state.name
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_BILLING_CITY_NAME
+            attr: $.message.order.billing.city.name
+            _RETURN_: attr are present   
+          - _NAME_: REQUIRED_BILLING_ORGANIZATION_DESCRIPTOR_NAME
+            attr: $.message.order.billing.organization.descriptor.name
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_BILLING_ORGANIZATION_ADDRESS
+            attr: $.message.order.billing.organization.address
+            _RETURN_: attr are present      
+          - _NAME_: REQUIRED_BILLING_EMAIL
+            attr: $.message.order.billing.email
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_PHONE
+            attr: $.message.order.billing.phone
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_TAX_ID
+            attr: $.message.order.billing.tax_id
+            _RETURN_: attr are present
+
+      - _NAME_: ON_CONFIRM_TIMESTAMPS
+        action:
+          - on_confirm
+        _RETURN_:
+          - _NAME_: REQUIRED_UPDATED_AT
+            attr: $.message.order.updated_at
+            reg:
+              - ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$
+            _RETURN_: attr follow regex reg    
+
+    status:
+      - _NAME_: STATUS_CONTEXT
+        action:
+          - status
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_: *ref_30
+      - _NAME_: REQUIRED_ORDER_ID
+        action:
+          - status
+        attr: $.message.order_id
+        _RETURN_: attr are present
+
+    on_status:
+      - _NAME_: ON_STATUS_CONTEXT
+        action:
+          - on_status
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_: &ref_30
+          - _NAME_: REQUIRED_ON_STATUS_CONTEXT
+            _RETURN_:
+              - _NAME_: REQUIRED_CONTEXT_DOMAIN
+                attr: $.context.domain
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_ACTION
+                attr: $.context.action
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_VERSION
+                attr: $.context.version
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_MESSAGE_ID
+                attr: $.context.message_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TRANSACTION_ID
+                attr: $.context.transaction_id
+                _RETURN_: attr are present
+              - _NAME_: REGEX_CONTEXT_TIMESTAMP
+                attr: $.context.timestamp
+                reg:
+                  - ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$
+                _RETURN_: attr follow regex reg
+
+      - _NAME_: ON_STATUS_ORDER
+        action:
+          - on_status
+        _RETURN_: &ref_51
+          - _NAME_: REQUIRED_ON_STATUS_ORDER
+            _RETURN_:
+              - _NAME_: REQUIRED_ORDER_ID
+                attr: $.message.order.id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ORDER_STATUS
+                attr: $.message.order.status
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ORDER_UPDATED_AT
+                attr: $.message.order.updated_at
+                _RETURN_: attr are present
+
+          - _NAME_: VALID_ENUM_ON_STATUS_ORDER
+            _RETURN_:
+              - _NAME_: VALID_ENUM_ORDER_STATUS
+                attr: $.message.order.status
+                enumList:
+                  - SOFT_CANCEL
+                  - CONFIRM_CANCEL
+                  - ACTIVE
+                  - COMPLETE
+                  - CANCELLED
+                _RETURN_: attr any in enumList
+              - _NAME_: REGEX_ON_STATUS_UPDATED_AT
+                attr: $.message.order.updated_at
+                reg:
+                  - ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$
+                _RETURN_: attr follow regex reg
+
+      - _NAME_: ON_STATUS_ITEMS
+        action:
+          - on_status
+        _RETURN_:
+          - _NAME_: REQUIRED_ITEMS
+            _RETURN_:
+              - _NAME_: REQUIRED_MESSAGE_ITEMS_ID
+                attr: $.message.order.items[*].id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_MESSAGE_ITEMS_ADD_ONS
+                attr: $.message.order.items[*].add_ons[*].id
+                _RETURN_: attr are present  
+              - _NAME_: REQUIRED_ITEMS_LOCATIONS
+                attr: $.message.order.items[*].location_ids[*]
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ITEMS_QUANTITY
+                attr: $.message.order.items[*].quantity.selected.count
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ITEMS_ADDONS
+                attr: $.message.order.items[*].add_ons[*].id
+                _RETURN_: attr are present
+
+      - _NAME_: ON_STATUS_ORDER_FULFILLMENTS
+        action:
+          - on_status
+        _RETURN_:
+          - _NAME_: REQUIRED_FULFILLMENT_ID
+            attr: $.message.order.fulfillments[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_NAME
+            attr: $.message.order.fulfillments[*].customer.person.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_AGE
+            attr: $.message.order.fulfillments[*].customer.person.age
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_DOB
+            attr: $.message.order.fulfillments[*].customer.person.dob
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_CUSTOMER_GENDER
+            attr: $.message.order.fulfillments[*].customer.person.gender
+            _RETURN_: attr are present     
+          - _NAME_: REQUIRED_CUSTOMER_CONTACT
+            attr: $.message.order.fulfillments[*].customer.contact.phone
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_CONTACT_EMAIL
+            attr: $.message.order.fulfillments[*].customer.contact.email
+            _RETURN_: attr are present
+
+      - _NAME_: ON_STATUS_PROVIDER
+        action:
+          - on_status
+        _RETURN_:
+          - _NAME_: REQUIRED_PROVIDER_ID
+            attr: $.message.order.provider.id
+            _RETURN_: attr are present
+
+      - _NAME_: ON_STATUS_ORDER_QUOTE
+        action:
+          - on_status
+        _RETURN_:
+          - _NAME_: REQUIRED_QUOTE_PRICE
+            attr: $.message.order.quote.price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_CURRENCY
+            attr: $.message.order.quote.price.currency
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_BREAKUP
+            attr: $.message.order.quote.breakup[*].price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_BREAKUP_PRICE_CURRENCY
+            attr: $.message.order.quote.breakup[*].price.currency
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_QUOTE_BREAKUP_TITLE
+            attr: $.message.order.quote.breakup[*].title
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_QUOTE_TTL
+            attr: $.message.order.quote.ttl
+            _RETURN_: attr are present
+
+      - _NAME_: ON_STATUS_PAYMENTS
+        action:
+          - on_status
+        _RETURN_:
+          - _NAME_: REQUIRED_PAYMENT_ID
+            attr: $.message.order.payments[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_PAYMENT_TYPE
+            attr: $.message.order.payments[*].type
+            _RETURN_: attr are present
+          - _NAME_: VALID_PAYMENT_TYPES
+            attr: $.message.order.payments[*].type
+            enumList:
+              - PRE-ORDER
+              - ON-FULFILLMENT
+              - PART-PAYMENT
+            _RETURN_: attr all in enumList  
+          - _NAME_: REQUIRED_PAYMENT_STATUS
+            attr: $.message.order.payments[*].status
+            _RETURN_: attr are present
+          - _NAME_: VALID_PAYMENT_STATUS
+            attr: $.message.order.payments[*].status
+            enumList:
+              - PAID
+              - NOT-PAID
+            _RETURN_: attr all in enumList
+
+          - _NAME_: VALID_ENUM_PAYMENTS
+            _RETURN_:
+              - _NAME_: VALID_ENUM_PAYMENTS_STATUS
+                attr: $.message.order.payments[*].status
+                enumList:
+                  - PAID
+                  - NOT-PAID
+                _RETURN_: attr any in enumList
+              - _NAME_: VALID_ENUM_PAYMENTS_TYPE
+                attr: $.message.order.payments[*].type
+                enumList:
+                  - PRE-ORDER
+                  - PART-PAYMENT
+                  - ON-FULFILLMENT
+                  - POST-FULFILLMENT
+                _RETURN_: attr any in enumList
+
+          - _NAME_: REQUIRED_PAYMENTS_LINKED_TAGS
+            _RETURN_:
+              - _NAME_: REQUIRED_LINKED_PAYMENT_TAG
+                attr: $.message.order.payments[*].tags[*].descriptor.code
+                enumList:
+                  - LINKED-PAYMENTS
+                  - ADV-DEPOSIT
+                  - FINAL-PAYMENT
+                _RETURN_: attr any in enumList
+
+      - _NAME_: ON_STATUS_ORDER_BILLING
+        action:
+          - on_status
+        _RETURN_:
+          - _NAME_: REQUIRED_BILLING_NAME
+            attr: $.message.order.billing.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_ADDRESS
+            attr: $.message.order.billing.address
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_STATE_NAME
+            attr: $.message.order.billing.state.name
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_BILLING_CITY_NAME
+            attr: $.message.order.billing.city.name
+            _RETURN_: attr are present   
+          - _NAME_: REQUIRED_BILLING_ORGANIZATION_DESCRIPTOR_NAME
+            attr: $.message.order.billing.organization.descriptor.name
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_BILLING_ORGANIZATION_ADDRESS
+            attr: $.message.order.billing.organization.address
+            _RETURN_: attr are present      
+          - _NAME_: REQUIRED_BILLING_EMAIL
+            attr: $.message.order.billing.email
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_PHONE
+            attr: $.message.order.billing.phone
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_TAX_ID
+            attr: $.message.order.billing.tax_id
+            _RETURN_: attr are present
+
+      - _NAME_: ON_STATUS_TAGS
+        action:
+          - on_status
+        _RETURN_:
+          - _NAME_: REQUIRED_TAGS
+            _RETURN_:
+              - _NAME_: REQUIRED_TAGS_DESCRIPTOR_CODE
+                attr: $.message.order.tags[*].descriptor.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_TAGS_LIST_DESCRIPTOR_CODE
+                attr: $.message.order.tags[*].list[*].descriptor.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_TAGS_LIST_VALUE
+                attr: $.message.order.tags[*].list[*].value
+                _RETURN_: attr are present
+
+      - _NAME_: ON_STATUS_DOCUMENTS
+        action:
+          - on_status
+        _RETURN_:
+          - _NAME_: REQUIRED_DOCUMENTS
+            _RETURN_:
+              - _NAME_: REQUIRED_DOCUMENTS_DESCRIPTOR_CODE
+                attr: $.message.order.documents[*].descriptor.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_DOCUMENTS_URL
+                attr: $.message.order.documents[*].url
+                _RETURN_: attr are present
+
+    update:
+      - _NAME_: UPDATE_CONTEXT
+        action:
+          - update
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_: *ref_30
+
+      - _NAME_: UPDATE_MESSAGE_1
+        action:
+          - update
+        _RETURN_:
+          - _NAME_: REQUIRED_UPDATE_TARGET
+            attr: $.message.update_target
+            _RETURN_: attr are present
+
+          - _NAME_: VALID_UPDATE_TARGET
+            attr: $.message.update_target
+            enumList:
+              - fulfillment
+              - payment
+              - billing
+              - items
+            _RETURN_: attr any in enumList
+
+          - _NAME_: REQUIRED_ORDER_ID
+            attr: $.message.order.id
+            _RETURN_: attr are present
+
+          - _NAME_: REQUIRED_FULFILLMENT_ID
+            attr: $.message.order.fulfillments[*].id
+            _RETURN_: attr are present
+
+          - _NAME_: REQUIRED_TAG_DESCRIPTOR_CODE
+            attr: $.message.order.fulfillments[*].tags[*].descriptor.code
+            _CONTINUE_: "!(attr are present)"
+            _RETURN_: attr are present
+
+          - _NAME_: VALID_TAG_DESCRIPTOR_CODE
+            attr: $.message.order.fulfillments[*].tags[*].descriptor.code
+            enumList:
+              - UPDATE_REQUEST
+              - MODIFY
+            _RETURN_: attr any in enumList
+
+          - _NAME_: REQUIRED_TAG_LIST_DESCRIPTOR_CODE
+            _CONTINUE_: "!(attr are present)"
+            attr: $.message.order.fulfillments[*].tags[*].list[*].descriptor.code
+            _RETURN_: attr are present
+
+          - _NAME_: REQUIRED_TAG_LIST_VALUE
+            attr: $.message.order.fulfillments[*].tags[*].list[*].value
+            _CONTINUE_: "!(attr are present)"
+            _RETURN_: attr are present
+
+    on_update:
+      - _NAME_: ON_UPDATE_CONTEXT
+        action:
+          - on_update
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_: &ref_30
+          - _NAME_: REQUIRED_ON_UPDATE_CONTEXT
+            _RETURN_:
+              - _NAME_: REQUIRED_CONTEXT_DOMAIN
+                attr: $.context.domain
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_ACTION
+                attr: $.context.action
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_VERSION
+                attr: $.context.version
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_MESSAGE_ID
+                attr: $.context.message_id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_CONTEXT_TRANSACTION_ID
+                attr: $.context.transaction_id
+                _RETURN_: attr are present
+              - _NAME_: REGEX_CONTEXT_TIMESTAMP
+                attr: $.context.timestamp
+                reg:
+                  - ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$
+                _RETURN_: attr follow regex reg
+
+      - _NAME_: ON_UPDATE_ORDER
+        action:
+          - on_update
+        _RETURN_: &ref_51
+          - _NAME_: REQUIRED_ON_UPDATE_ORDER
+            _RETURN_:
+              - _NAME_: REQUIRED_ORDER_ID
+                attr: $.message.order.id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ORDER_STATUS
+                attr: $.message.order.status
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ORDER_UPDATED_AT
+                attr: $.message.order.updated_at
+                _RETURN_: attr are present
+
+          - _NAME_: VALID_ENUM_ON_UPDATE_ORDER
+            _RETURN_:
+              - _NAME_: VALID_ENUM_ORDER_STATUS
+                attr: $.message.order.status
+                enumList:
+                  - SOFT-CANCEL
+                  - CONFIRM-CANCEL
+                  - SOFT-UPDATE
+                  - CONFIRM-UPDATE
+                  - ACTIVE
+                  - COMPLETE
+                  - CANCELLED
+                _RETURN_: attr any in enumList
+              - _NAME_: REGEX_ON_UPDATE_UPDATED_AT
+                attr: $.message.order.updated_at
+                reg:
+                  - ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$
+                _RETURN_: attr follow regex reg
+
+      - _NAME_: ON_UPDATE_ITEMS
+        action:
+          - on_update
+        _RETURN_:
+          - _NAME_: REQUIRED_ITEMS
+            _RETURN_:
+              - _NAME_: REQUIRED_MESSAGE_ITEMS_ID
+                attr: $.message.order.items[*].id
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_MESSAGE_ITEMS_ADD_ONS
+                attr: $.message.order.items[*].add_ons[*].id
+                _RETURN_: attr are present  
+              - _NAME_: REQUIRED_ITEMS_LOCATIONS
+                attr: $.message.order.items[*].location_ids[*]
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ITEMS_QUANTITY
+                attr: $.message.order.items[*].quantity.selected.count
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_ITEMS_ADDONS
+                attr: $.message.order.items[*].add_ons[*].id
+                _RETURN_: attr are present
+
+      - _NAME_: ON_UPDATE_ORDER_FULFILLMENTS
+        action:
+          - on_update
+        _RETURN_:
+          - _NAME_: REQUIRED_FULFILLMENT_ID
+            attr: $.message.order.fulfillments[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_NAME
+            attr: $.message.order.fulfillments[*].customer.person.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_AGE
+            attr: $.message.order.fulfillments[*].customer.person.age
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_DOB
+            attr: $.message.order.fulfillments[*].customer.person.dob
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_CUSTOMER_GENDER
+            attr: $.message.order.fulfillments[*].customer.person.gender
+            _RETURN_: attr are present     
+          - _NAME_: REQUIRED_CUSTOMER_CONTACT
+            attr: $.message.order.fulfillments[*].customer.contact.phone
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_CUSTOMER_CONTACT_EMAIL
+            attr: $.message.order.fulfillments[*].customer.contact.email
+            _RETURN_: attr are present
+
+      - _NAME_: ON_UPDATE_PROVIDER
+        action:
+          - on_update
+        _RETURN_:
+          - _NAME_: REQUIRED_PROVIDER_ID
+            attr: $.message.order.provider.id
+            _RETURN_: attr are present
+
+      - _NAME_: ON_UPDATE_ORDER_QUOTE
+        action:
+          - on_update
+        _RETURN_:
+          - _NAME_: REQUIRED_QUOTE_PRICE
+            attr: $.message.order.quote.price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_CURRENCY
+            attr: $.message.order.quote.price.currency
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_BREAKUP
+            attr: $.message.order.quote.breakup[*].price.value
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_QUOTE_BREAKUP_PRICE_CURRENCY
+            attr: $.message.order.quote.breakup[*].price.currency
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_QUOTE_BREAKUP_TITLE
+            attr: $.message.order.quote.breakup[*].title
+            _RETURN_: attr are present  
+          - _NAME_: REQUIRED_QUOTE_TTL
+            attr: $.message.order.quote.ttl
+            _RETURN_: attr are present
+
+      - _NAME_: ON_UPDATE_PAYMENTS
+        action:
+          - on_update
+        _RETURN_:
+          - _NAME_: REQUIRED_PAYMENT_ID
+            attr: $.message.order.payments[*].id
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_PAYMENT_TYPE
+            attr: $.message.order.payments[*].type
+            _RETURN_: attr are present
+          - _NAME_: VALID_PAYMENT_TYPES
+            attr: $.message.order.payments[*].type
+            enumList:
+              - PRE-ORDER
+              - ON-FULFILLMENT
+              - PART-PAYMENT
+            _RETURN_: attr all in enumList  
+          - _NAME_: REQUIRED_PAYMENT_STATUS
+            attr: $.message.order.payments[*].status
+            _RETURN_: attr are present
+          - _NAME_: VALID_PAYMENT_STATUS
+            attr: $.message.order.payments[*].status
+            enumList:
+              - PAID
+              - NOT-PAID
+            _RETURN_: attr all in enumList
+
+          - _NAME_: VALID_ENUM_PAYMENTS
+            _RETURN_:
+              - _NAME_: VALID_ENUM_PAYMENTS_STATUS
+                attr: $.message.order.payments[*].status
+                enumList:
+                  - PAID
+                  - NOT-PAID
+                _RETURN_: attr any in enumList
+              - _NAME_: VALID_ENUM_PAYMENTS_TYPE
+                attr: $.message.order.payments[*].type
+                enumList:
+                  - PRE-ORDER
+                  - PART-PAYMENT
+                  - ON-FULFILLMENT
+                  - POST-FULFILLMENT
+                _RETURN_: attr any in enumList
+
+          - _NAME_: REQUIRED_PAYMENTS_LINKED_TAGS
+            _RETURN_:
+              - _NAME_: REQUIRED_LINKED_PAYMENT_TAG
+                attr: $.message.order.payments[*].tags[*].descriptor.code
+                enumList:
+                  - LINKED-PAYMENTS
+                  - ADV-DEPOSIT
+                  - FINAL-PAYMENT
+                _RETURN_: attr any in enumList
+
+      - _NAME_: ON_UPDATE_ORDER_BILLING
+        action:
+          - on_update
+        _RETURN_:
+          - _NAME_: REQUIRED_BILLING_NAME
+            attr: $.message.order.billing.name
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_ADDRESS
+            attr: $.message.order.billing.address
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_STATE_NAME
+            attr: $.message.order.billing.state.name
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_BILLING_CITY_NAME
+            attr: $.message.order.billing.city.name
+            _RETURN_: attr are present   
+          - _NAME_: REQUIRED_BILLING_ORGANIZATION_DESCRIPTOR_NAME
+            attr: $.message.order.billing.organization.descriptor.name
+            _RETURN_: attr are present 
+          - _NAME_: REQUIRED_BILLING_ORGANIZATION_ADDRESS
+            attr: $.message.order.billing.organization.address
+            _RETURN_: attr are present      
+          - _NAME_: REQUIRED_BILLING_EMAIL
+            attr: $.message.order.billing.email
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_PHONE
+            attr: $.message.order.billing.phone
+            _RETURN_: attr are present
+          - _NAME_: REQUIRED_BILLING_TAX_ID
+            attr: $.message.order.billing.tax_id
+            _RETURN_: attr are present
+
+      - _NAME_: ON_UPDATE_TAGS
+        action:
+          - on_update
+        _RETURN_:
+          - _NAME_: REQUIRED_TAGS
+            _RETURN_:
+              - _NAME_: REQUIRED_TAGS_DESCRIPTOR_CODE
+                attr: $.message.order.tags[*].descriptor.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_TAGS_LIST_DESCRIPTOR_CODE
+                attr: $.message.order.tags[*].list[*].descriptor.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_TAGS_LIST_VALUE
+                attr: $.message.order.tags[*].list[*].value
+                _RETURN_: attr are present
+
+      - _NAME_: ON_UPDATE_DOCUMENTS
+        action:
+          - on_update
+        _RETURN_:
+          - _NAME_: REQUIRED_DOCUMENTS
+            _RETURN_:
+              - _NAME_: REQUIRED_DOCUMENTS_DESCRIPTOR_CODE
+                attr: $.message.order.documents[*].descriptor.code
+                _RETURN_: attr are present
+              - _NAME_: REQUIRED_DOCUMENTS_URL
+                attr: $.message.order.documents[*].url
+                _RETURN_: attr are present
+
+    cancel:
+      - _NAME_: CANCEL_CONTEXT
+        action:
+          - cancel
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_: *ref_30
+
+      - _NAME_: CANCEL_MESSAGE_1
+        action:
+          - cancel
+        _RETURN_:
+          - _NAME_: REQUIRED_CANCELLATION_ID
+            attr: $.message.cancellation_reason_id
+            _RETURN_: attr are present
+
+          - _NAME_: REQUIRED_CANCELLATION_SHORT_DESC
+            attr: $.message.descriptor.short_desc
+            _RETURN_: attr are present
+
+          - _NAME_: REQUIRED_CANCELLATION_LONG_DESC
+            attr: $.message.descriptor.long_desc
+            _RETURN_: attr are present
+
+          - _NAME_: REQUIRED_ORDER_ID
+            attr: $.message.order_id
+            _RETURN_: attr are present
+
+          - _NAME_: VALID_CANCELLATION_REASON_ID
+            attr: $.message.cancellation_reason_id
+            enumList:
+              - "000"
+              - "001"
+              - "002"
+              - "003"
+              - "004"
+              - "005"
+              - "011"
+              - "012"
+              - "013"
+              - "014"
+            _RETURN_: attr any in enumList
+
+    on_cancel:
+      - _NAME_: ON_CANCEL_CONTEXT
+        action:
+          - on_cancel
+        domain:
+          - ONDC:TRV13
+        version:
+          - 2.0.0
+        _RETURN_: *ref_30
+
+      - _NAME_: ON_CANCEL_MESSAGE_1
+        action:
+          - on_cancel
+        _RETURN_:
+          - _NAME_: REQUIRED_ORDER_ID
+            attr: $.message.order.id
+            _RETURN_: attr are present
+
+          - _NAME_: REQUIRED_ORDER_STATUS
+            attr: $.message.order.status
+            _RETURN_: attr are present
+
+          - _NAME_: VALID_ORDER_STATUS
+            attr: $.message.order.status
+            enumList:
+              - CANCELLED
+            _RETURN_: attr any in enumList
+
+          - _NAME_: REQUIRED_CANCELLED_BY
+            attr: $.message.order.cancellation.cancelled_by
+            _RETURN_: attr are present
+
+          - _NAME_: REQUIRED_CANCELLATION_REASON_ID
+            attr: $.message.order.cancellation.reason.id
+            _RETURN_: attr are present
+
+          # - _NAME_: REQUIRED_CANCELLATION_SHORT_DESC
+          #   attr: $.message.order.cancellation.reason.descriptor.short_desc
+          #   _RETURN_: attr are present
+
+          # - _NAME_: REQUIRED_CANCELLATION_LONG_DESC
+          #   attr: $.message.order.cancellation.reason.descriptor.long_desc
+          #   _RETURN_: attr are present
+
+          - _NAME_: REQUIRED_UPDATED_AT
+            attr: $.message.order.updated_at
+            _RETURN_: attr are present
+
+          - _NAME_: VALID_CANCELLATION_REASON_ID
+            attr: $.message.order.cancellation.reason.id
+            enumList:
+              - "000"
+              - "001"
+              - "002"
+              - "003"
+              - "004"
+              - "005"
+              - "011"
+              - "012"
+              - "013"
+              - "014"
+            _RETURN_: attr any in enumList
+
+  _SESSION_DATA_:
+    trans: {}


### PR DESCRIPTION
- Wrap REQUIRED_ITEM_ADDON_ID in parent ITEM_ADDON_VALIDATION rule
- Parent uses _CONTINUE_: !(attr are present) on add_ons array
- Child rule checks add_ons[*].id only when add_ons exists
- No add_ons in items → skip (no error)
- add_ons exists without id → error
- add_ons exists with valid id → pass