### PR TITLE
fix: remove unconditional REQUIRED_ITEM_ADDON_ID from SELECT validation (TRV13 2.0.1)

### DIFF
--- a/api-service/src/config/build.yaml
+++ b/api-service/src/config/build.yaml
@@ -9896,9 +9896,6 @@ x-validations:
           - _NAME_: REQUIRED_ITEM_QUANTITY_SELECTED
             attr: $.message.order.items[*].quantity.selected.count
             _RETURN_: attr are present
-          - _NAME_: REQUIRED_ITEM_ADDON_ID
-            attr: $.message.order.items[*].add_ons[*].id
-            _RETURN_: attr are present
 
       - _NAME_: SELECT_ORDER_FULFILLMENTS
         action:


### PR DESCRIPTION
add_ons is optional in SELECT — removed rule that incorrectly required add_ons[*].id on every SELECT call, failing when no add-on is selected.