### PR TITLE
fix: start stops removed instruction and parent_stop_id in metro TRV1…

### DIFF
--- a/mock-service/src/config/mock-config/TRV11/METRO/2.1.0/on_update/on_update_end_stop_1/generator.ts
+++ b/mock-service/src/config/mock-config/TRV11/METRO/2.1.0/on_update/on_update_end_stop_1/generator.ts
@@ -126,14 +126,21 @@ export async function onUpdateStopEndGenerator(
   }
 
   existingPayload.message.order.fulfillments =
-    existingPayload?.message?.order?.fulfillments?.map((fulfillment: any) => {
-      if (fulfillment?.type === "TRIP") {
-        return {
-          ...fulfillment,
-          stops: updatedStops,
-        };
-      } else return fulfillment;
-    });
+  existingPayload?.message?.order?.fulfillments?.map((fulfillment: any) => {
+    if (fulfillment?.type === "TRIP") {
+      return {
+        ...fulfillment,
+        stops: updatedStops?.map((stop: any) => {
+          if (stop?.type === "START") {
+            const { instructions, parent_stop_id, ...rest } = stop;
+            return rest; 
+          }
+          return stop;
+        }),
+      };
+    }
+    return fulfillment;
+  });
 
   // Update item prices based on TRIP fulfillment stops length
   const tripFulfillment = existingPayload.message.order.fulfillments?.find(


### PR DESCRIPTION
…1 2.1.0 in dev